### PR TITLE
RGB Backlight: Dont update while screen is off and other improvements

### DIFF
--- a/lib/drivers/rgb_backlight.c
+++ b/lib/drivers/rgb_backlight.c
@@ -18,6 +18,8 @@
 */
 
 #include "rgb_backlight.h"
+#include "colors.h"
+#include "core/timer.h"
 #include <furi_hal.h>
 #include <storage/storage.h>
 #include <toolbox/saved_struct.h>
@@ -205,7 +207,7 @@ uint8_t rgb_backlight_get_rainbow_saturation() {
 
 static void rainbow_timer(void* ctx) {
     UNUSED(ctx);
-    rgb_backlight_update(rgb_state.last_brightness, true);
+    rgb_backlight_rainbow_mode();
 }
 
 void rgb_backlight_reconfigure(bool enabled) {
@@ -226,7 +228,50 @@ void rgb_backlight_reconfigure(bool enabled) {
         rgb_state.rainbow_timer = NULL;
     }
     rgb_state.rainbow_hsv.s = rgb_settings.rainbow_saturation;
-    rgb_backlight_update(rgb_state.last_brightness, false);
+    rgb_backlight_update(rgb_state.last_brightness, true);
+
+    furi_check(furi_mutex_release(rgb_state.mutex) == FuriStatusOk);
+}
+
+void rgb_backlight_rainbow_mode() {
+    if(!rgb_state.settings_loaded) return;
+    furi_check(furi_mutex_acquire(rgb_state.mutex, FuriWaitForever) == FuriStatusOk);
+
+    if(!rgb_state.enabled || rgb_settings.rainbow_mode == RGBBacklightRainbowModeOff ||
+       !rgb_state.last_brightness) {
+        furi_check(furi_mutex_release(rgb_state.mutex) == FuriStatusOk);
+        return;
+    }
+
+    rgb_state.rainbow_hsv.h += rgb_settings.rainbow_speed;
+
+    RgbColor rgb;
+    hsv2rgb(&rgb_state.rainbow_hsv, &rgb);
+
+    switch(rgb_settings.rainbow_mode) {
+    case RGBBacklightRainbowModeWave: {
+        HsvColor hsv = rgb_state.rainbow_hsv;
+        for(uint8_t i = 0; i < SK6805_get_led_count(); i++) {
+            if(i) {
+                hsv.h += (50 * i);
+                hsv2rgb(&hsv, &rgb);
+            }
+            SK6805_set_led_color(i, rgb.r, rgb.g, rgb.b);
+        }
+        break;
+    }
+
+    case RGBBacklightRainbowModeSolid:
+        for(uint8_t i = 0; i < SK6805_get_led_count(); i++) {
+            SK6805_set_led_color(i, rgb.r, rgb.g, rgb.b);
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    SK6805_update();
 
     if(rgb_state.enabled && rgb_settings.rainbow_mode == RGBBacklightRainbowModeOff)
         SK6805_update();
@@ -234,11 +279,11 @@ void rgb_backlight_reconfigure(bool enabled) {
     furi_check(furi_mutex_release(rgb_state.mutex) == FuriStatusOk);
 }
 
-void rgb_backlight_update(uint8_t brightness, bool tick) {
+void rgb_backlight_update(uint8_t brightness, bool forced) {
     if(!rgb_state.settings_loaded) return;
     furi_check(furi_mutex_acquire(rgb_state.mutex, FuriWaitForever) == FuriStatusOk);
 
-    if(!rgb_state.enabled) {
+    if(!rgb_state.enabled || (brightness == rgb_state.last_brightness && !forced)) {
         furi_check(furi_mutex_release(rgb_state.mutex) == FuriStatusOk);
         return;
     }
@@ -258,29 +303,14 @@ void rgb_backlight_update(uint8_t brightness, bool tick) {
 
     case RGBBacklightRainbowModeWave:
     case RGBBacklightRainbowModeSolid: {
-        if(tick && brightness) {
-            rgb_state.rainbow_hsv.h += rgb_settings.rainbow_speed;
-        } else {
-            rgb_state.rainbow_hsv.v = brightness;
-        }
-
-        RgbColor rgb;
-        hsv2rgb(&rgb_state.rainbow_hsv, &rgb);
-
-        if(rgb_settings.rainbow_mode == RGBBacklightRainbowModeWave) {
-            HsvColor hsv = rgb_state.rainbow_hsv;
+        if(!brightness) {
+            furi_timer_stop(rgb_state.rainbow_timer);
             for(uint8_t i = 0; i < SK6805_get_led_count(); i++) {
-                if(i) {
-                    hsv.h += (50 * i);
-                    hsv2rgb(&hsv, &rgb);
-                }
-                SK6805_set_led_color(i, rgb.r, rgb.g, rgb.b);
+                SK6805_set_led_color(i, 0, 0, 0);
             }
-        } else {
-            for(uint8_t i = 0; i < SK6805_get_led_count(); i++) {
-                SK6805_set_led_color(i, rgb.r, rgb.g, rgb.b);
-            }
-        }
+        } else if(!rgb_state.last_brightness)
+            furi_timer_start(rgb_state.rainbow_timer, rgb_settings.rainbow_interval);
+        rgb_state.rainbow_hsv.v = brightness;
         break;
     }
 

--- a/lib/drivers/rgb_backlight.h
+++ b/lib/drivers/rgb_backlight.h
@@ -98,12 +98,6 @@ uint8_t rgb_backlight_get_rainbow_saturation();
 void rgb_backlight_reconfigure(bool enabled);
 
 /**
- * @brief Run the RGB rainbowmode
- *
- */
-void rgb_backlight_rainbow_mode();
-
-/**
  * @brief Apply current RGB lighting settings
  *
  * @param brightness Backlight intensity (0-255)

--- a/lib/drivers/rgb_backlight.h
+++ b/lib/drivers/rgb_backlight.h
@@ -98,12 +98,18 @@ uint8_t rgb_backlight_get_rainbow_saturation();
 void rgb_backlight_reconfigure(bool enabled);
 
 /**
+ * @brief Run the RGB rainbowmode
+ *
+ */
+void rgb_backlight_rainbow_mode();
+
+/**
  * @brief Apply current RGB lighting settings
  *
  * @param brightness Backlight intensity (0-255)
- * @param tick       Whether this update was a tick (for rainbow)
+ * @param forced force a update even brightness doesnt changed
  */
-void rgb_backlight_update(uint8_t brightness, bool tick);
+void rgb_backlight_update(uint8_t brightness, bool forced);
 
 #ifdef __cplusplus
 }

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -2963,7 +2963,6 @@ Function,+,rgb_backlight_get_rainbow_mode,RGBBacklightRainbowMode,
 Function,+,rgb_backlight_get_rainbow_saturation,uint8_t,
 Function,+,rgb_backlight_get_rainbow_speed,uint8_t,
 Function,-,rgb_backlight_load_settings,void,_Bool
-Function,-,rgb_backlight_rainbow_mode,void,
 Function,+,rgb_backlight_reconfigure,void,_Bool
 Function,+,rgb_backlight_save_settings,void,
 Function,+,rgb_backlight_set_color,void,"uint8_t, const RgbColor*"

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -2963,6 +2963,7 @@ Function,+,rgb_backlight_get_rainbow_mode,RGBBacklightRainbowMode,
 Function,+,rgb_backlight_get_rainbow_saturation,uint8_t,
 Function,+,rgb_backlight_get_rainbow_speed,uint8_t,
 Function,-,rgb_backlight_load_settings,void,_Bool
+Function,-,rgb_backlight_rainbow_mode,void,
 Function,+,rgb_backlight_reconfigure,void,_Bool
 Function,+,rgb_backlight_save_settings,void,
 Function,+,rgb_backlight_set_color,void,"uint8_t, const RgbColor*"


### PR DESCRIPTION
# What's new

- when the screen turns dark stop updating the rgb rainbow
- rgb rainbow mode has is own function and brightness change has is own function

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable
