### PR TITLE
Add is_connected api for expansion \w @Willy-JL

### DIFF
--- a/applications/services/expansion/expansion.c
+++ b/applications/services/expansion/expansion.c
@@ -18,6 +18,7 @@ typedef enum {
     ExpansionStateDisabled,
     ExpansionStateEnabled,
     ExpansionStateRunning,
+    ExpansionStateConnectionEstablished,
 } ExpansionState;
 
 typedef enum {
@@ -26,6 +27,7 @@ typedef enum {
     ExpansionMessageTypeSetListenSerial,
     ExpansionMessageTypeModuleConnected,
     ExpansionMessageTypeModuleDisconnected,
+    ExpansionMessageTypeConnectionEstablished,
 } ExpansionMessageType;
 
 typedef union {
@@ -68,13 +70,21 @@ static void expansion_detect_callback(void* context) {
     UNUSED(status);
 }
 
-static void expansion_worker_callback(void* context) {
+static void expansion_worker_callback(void* context, ExpansionWorkerCallbackReason reason) {
     furi_assert(context);
     Expansion* instance = context;
 
-    ExpansionMessage message = {
-        .type = ExpansionMessageTypeModuleDisconnected,
-        .api_lock = NULL, // Not locking the API here to avoid a deadlock
+    ExpansionMessage message;
+    switch(reason) {
+    case ExpansionWorkerCallbackReasonExit:
+        message.type = ExpansionMessageTypeModuleDisconnected;
+        message.api_lock = NULL; // Not locking the API here to avoid a deadlock
+        break;
+
+    case ExpansionWorkerCallbackReasonConnected:
+        message.type = ExpansionMessageTypeConnectionEstablished;
+        message.api_lock = api_lock_alloc_locked();
+        break;
     };
 
     const FuriStatus status = furi_message_queue_put(instance->queue, &message, FuriWaitForever);
@@ -105,7 +115,9 @@ static void
 
     if(instance->state == ExpansionStateDisabled) {
         return;
-    } else if(instance->state == ExpansionStateRunning) {
+    } else if(
+        instance->state == ExpansionStateRunning ||
+        instance->state == ExpansionStateConnectionEstablished) {
         expansion_worker_stop(instance->worker);
         expansion_worker_free(instance->worker);
     } else {
@@ -122,7 +134,8 @@ static void expansion_control_handler_set_listen_serial(
     const ExpansionMessageData* data) {
     furi_check(data->serial_id < FuriHalSerialIdMax);
 
-    if(instance->state == ExpansionStateRunning) {
+    if(instance->state == ExpansionStateRunning ||
+       instance->state == ExpansionStateConnectionEstablished) {
         expansion_worker_stop(instance->worker);
         expansion_worker_free(instance->worker);
 
@@ -160,7 +173,8 @@ static void expansion_control_handler_module_disconnected(
     Expansion* instance,
     const ExpansionMessageData* data) {
     UNUSED(data);
-    if(instance->state != ExpansionStateRunning) {
+    if(instance->state != ExpansionStateRunning &&
+       instance->state != ExpansionStateConnectionEstablished) {
         return;
     }
 
@@ -168,6 +182,18 @@ static void expansion_control_handler_module_disconnected(
     expansion_worker_free(instance->worker);
     furi_hal_serial_control_set_expansion_callback(
         instance->serial_id, expansion_detect_callback, instance);
+}
+
+static void expansion_control_handler_module_connection_established(
+    Expansion* instance,
+    const ExpansionMessageData* data) {
+    UNUSED(data);
+    if(instance->state != ExpansionStateRunning &&
+       instance->state != ExpansionStateConnectionEstablished) {
+        return;
+    }
+
+    instance->state = ExpansionStateConnectionEstablished;
 }
 
 typedef void (*ExpansionControlHandler)(Expansion*, const ExpansionMessageData*);
@@ -178,6 +204,8 @@ static const ExpansionControlHandler expansion_control_handlers[] = {
     [ExpansionMessageTypeSetListenSerial] = expansion_control_handler_set_listen_serial,
     [ExpansionMessageTypeModuleConnected] = expansion_control_handler_module_connected,
     [ExpansionMessageTypeModuleDisconnected] = expansion_control_handler_module_disconnected,
+    [ExpansionMessageTypeConnectionEstablished] =
+        expansion_control_handler_module_connection_established,
 };
 
 static int32_t expansion_control(void* context) {
@@ -247,6 +275,11 @@ void expansion_disable(Expansion* instance) {
 
     furi_message_queue_put(instance->queue, &message, FuriWaitForever);
     api_lock_wait_unlock_and_free(message.api_lock);
+}
+
+bool expansion_is_connected(Expansion* instance) {
+    furi_check(instance);
+    return instance->state == ExpansionStateConnectionEstablished;
 }
 
 void expansion_set_listen_serial(Expansion* instance, FuriHalSerialId serial_id) {

--- a/applications/services/expansion/expansion.h
+++ b/applications/services/expansion/expansion.h
@@ -51,6 +51,14 @@ void expansion_enable(Expansion* instance);
 void expansion_disable(Expansion* instance);
 
 /**
+ * @brief Check support for expansion modules if its currently connected.
+ *
+ * @param[in,out] instance pointer to the Expansion instance.
+ *
+ */
+bool expansion_is_connected(Expansion* instance);
+
+/**
  * @brief Enable support for expansion modules on designated serial port.
  *
  * Only one serial port can be used to communicate with an expansion

--- a/applications/services/expansion/expansion_worker.c
+++ b/applications/services/expansion/expansion_worker.c
@@ -223,6 +223,7 @@ static bool expansion_worker_handle_state_handshake(
 
         if(furi_hal_serial_is_baud_rate_supported(instance->serial_handle, baud_rate)) {
             instance->state = ExpansionWorkerStateConnected;
+            instance->callback(instance->cb_context, ExpansionWorkerCallbackReasonConnected);
             // Send response at previous baud rate
             if(!expansion_worker_send_status_response(instance, ExpansionFrameErrorNone)) break;
             furi_hal_serial_set_br(instance->serial_handle, baud_rate);
@@ -351,7 +352,7 @@ static int32_t expansion_worker(void* context) {
 
     // Do not invoke worker callback on user-requested exit
     if((instance->exit_reason != ExpansionWorkerExitReasonUser) && (instance->callback != NULL)) {
-        instance->callback(instance->cb_context);
+        instance->callback(instance->cb_context, ExpansionWorkerCallbackReasonExit);
     }
 
     return 0;

--- a/applications/services/expansion/expansion_worker.h
+++ b/applications/services/expansion/expansion_worker.h
@@ -17,6 +17,11 @@
  */
 typedef struct ExpansionWorker ExpansionWorker;
 
+typedef enum {
+    ExpansionWorkerCallbackReasonExit,
+    ExpansionWorkerCallbackReasonConnected,
+} ExpansionWorkerCallbackReason;
+
 /**
  * @brief Worker callback type.
  *
@@ -24,7 +29,7 @@ typedef struct ExpansionWorker ExpansionWorker;
  *
  * @param[in,out] context pointer to a user-defined object.
  */
-typedef void (*ExpansionWorkerCallback)(void* context);
+typedef void (*ExpansionWorkerCallback)(void* context, ExpansionWorkerCallbackReason reason);
 
 /**
  * @brief Create an expansion worker instance.

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1033,6 +1033,7 @@ Function,-,exp2l,long double,long double
 Function,+,expansion_disable,void,Expansion*
 Function,+,expansion_enable,void,Expansion*
 Function,+,expansion_get_settings,ExpansionSettings*,Expansion*
+Function,+,expansion_is_connected,_Bool,Expansion*
 Function,+,expansion_set_listen_serial,void,"Expansion*, FuriHalSerialId"
 Function,-,expansion_settings_load,_Bool,ExpansionSettings*
 Function,+,expansion_settings_save,_Bool,ExpansionSettings*


### PR DESCRIPTION
# What's new

- Added new API to expansion to get the information if an expansion is initialized
- The expansion_worker communicates back to the control if there is an RPC connection
- new state for expansion for an established connection

@Willy-JL was heavily involved

-----
# For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ ] I've confirmed the bug to be fixed / feature to be stable
