### PR TITLE
add support for OFW - declare reverse_mac

### DIFF
--- a/applications/system/findmy/findmy.c
+++ b/applications/system/findmy/findmy.c
@@ -154,3 +154,12 @@ FindMyType findmy_data_get_type(uint8_t data[EXTRA_BEACON_MAX_DATA_SIZE]) {
         return FindMyTypeSamsung;
     }
 }
+
+void furi_hal_bt_reverse_mac_addr(uint8_t mac_addr[GAP_MAC_ADDR_SIZE]) {
+    uint8_t tmp;
+    for(size_t i = 0; i < GAP_MAC_ADDR_SIZE / 2; i++) {
+        tmp = mac_addr[i];
+        mac_addr[i] = mac_addr[GAP_MAC_ADDR_SIZE - 1 - i];
+        mac_addr[GAP_MAC_ADDR_SIZE - 1 - i] = tmp;
+    }
+}

--- a/applications/system/findmy/findmy_i.h
+++ b/applications/system/findmy/findmy_i.h
@@ -20,6 +20,9 @@
 #include <gui/modules/popup.h>
 #include "scenes/findmy_scene.h"
 #include "helpers/base64.h"
+#if FW_ORIGIN_Official
+void furi_hal_bt_reverse_mac_addr(uint8_t mac_addr[GAP_MAC_ADDR_SIZE]);
+#endif
 
 struct FindMy {
     Gui* gui;


### PR DESCRIPTION
# What's new

- Added if statement in findmy_i.h to declare ```furi_hal_bt_reverse_mac_addr``` if on OFW. This will help when merging MNTM changes to origin repo

-----
# For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ ] I've confirmed the bug to be fixed / feature to be stable
