### PR TITLE
JS: Add `badusb.altPrint()` and `badusb.altPrintln()` to avoid layout issues on Windows targets

### DIFF
--- a/applications/system/js_app/examples/apps/Scripts/badusb_demo.js
+++ b/applications/system/js_app/examples/apps/Scripts/badusb_demo.js
@@ -26,6 +26,12 @@ if (badusb.isConnected()) {
     badusb.println("Flipper Name: " + flipper.getName());
     badusb.println("Battery level: " + to_string(flipper.getBatteryCharge()) + "%");
 
+    // Alt+Numpad method works only on Windows!!!
+    badusb.altPrintln("This was printed with Alt+Numpad method!");
+
+    // There's also badusb.print() and badusb.altPrint()
+    // which don't add the return at the end
+
     notify.success();
 } else {
     print("USB not connected");

--- a/applications/system/js_app/modules/js_badusb.c
+++ b/applications/system/js_app/modules/js_badusb.c
@@ -400,24 +400,30 @@ static void js_badusb_println(struct mjs* mjs) {
 }
 
 // Simulates typing a character using the ALT key and Numpad ASCII code
-static void alt_numpad_type_character(char character) {
+static void alt_numpad_type_character(struct mjs* mjs, char character) {
+    const uint32_t delay_ms = 50; // Example delay
+
     // Press and hold the ALT key
     furi_hal_hid_kb_press(KEY_MOD_LEFT_ALT);
+    js_delay_with_flags(mjs, delay_ms);
 
     // Convert the character to its ASCII value and then to a string
     char ascii_str[4];
     snprintf(ascii_str, sizeof(ascii_str), "%03d", character);
 
-    // For each digit in the ASCII string, create a temp string and press/release the corresponding numpad key
+    // For each digit in the ASCII string, press and release the corresponding numpad key
     for(size_t i = 0; ascii_str[i] != '\0'; i++) {
-        char temp_str[2] = {ascii_str[i], '\0'}; // Create a temporary string for each digit
-        uint16_t numpad_keycode = get_keycode_by_name(temp_str, 1);
+        char digitStr[2] = {ascii_str[i], '\0'};
+        uint16_t numpad_keycode = get_keycode_by_name(digitStr, 1);
         furi_hal_hid_kb_press(numpad_keycode);
+        js_delay_with_flags(mjs, delay_ms);
         furi_hal_hid_kb_release(numpad_keycode);
+        js_delay_with_flags(mjs, delay_ms);
     }
 
     // Release the ALT key
     furi_hal_hid_kb_release(KEY_MOD_LEFT_ALT);
+    js_delay_with_flags(mjs, delay_ms);
 }
 
 static void js_badusb_altPrintln(struct mjs* mjs) {
@@ -431,7 +437,7 @@ static void js_badusb_altPrintln(struct mjs* mjs) {
     size_t text_len;
     const char* text = mjs_get_string(mjs, &obj_string, &text_len);
     for (size_t i = 0; i < text_len; ++i) {
-        alt_numpad_type_character(text[i]);
+        alt_numpad_type_character(mjs, text[i]);
     }
 
     // Simulate pressing the ENTER key at the end

--- a/applications/system/js_app/modules/js_badusb.c
+++ b/applications/system/js_app/modules/js_badusb.c
@@ -401,7 +401,7 @@ static void js_badusb_println(struct mjs* mjs) {
 
 // Simulates typing a character using the ALT key and Numpad ASCII code
 static void alt_numpad_type_character(struct mjs* mjs, char character) {
-    const uint32_t delay_ms = 50; // Example delay
+    const uint32_t delay_ms = 200; // Example delay
 
     // Press and hold the ALT key
     furi_hal_hid_kb_press(KEY_MOD_LEFT_ALT);

--- a/applications/system/js_app/modules/js_badusb.c
+++ b/applications/system/js_app/modules/js_badusb.c
@@ -450,6 +450,7 @@ static void js_badusb_altPrint(struct mjs* mjs) {
     mjs_return(mjs, MJS_UNDEFINED);
 }
 
+// Ensure js_badusb_altPrintln is only defined once and correctly calls js_badusb_altPrint
 static void js_badusb_altPrintln(struct mjs* mjs) {
     mjs_val_t obj_string = mjs_arg(mjs, 0);
     if (!mjs_is_string(obj_string)) {

--- a/applications/system/js_app/modules/js_badusb.c
+++ b/applications/system/js_app/modules/js_badusb.c
@@ -402,7 +402,7 @@ static void js_badusb_println(struct mjs* mjs) {
 static bool ducky_altchar(struct mjs* mjs, const char* ascii_code) {
     // Hold the ALT key
     furi_hal_hid_kb_press(KEY_MOD_LEFT_ALT);
-    js_delay_with_flags(mjs, 50);
+    // js_delay_with_flags(mjs, 50);
 
     // Loop through each digit of the ASCII code and press the corresponding numpad key
     for(size_t i = 0; ascii_code[i] != '\0'; i++) {
@@ -413,14 +413,14 @@ static bool ducky_altchar(struct mjs* mjs, const char* ascii_code) {
             continue;
         }
         furi_hal_hid_kb_press(numpad_keycode);
-        js_delay_with_flags(mjs, 50);
+        // js_delay_with_flags(mjs, 50);
         furi_hal_hid_kb_release(numpad_keycode);
-        js_delay_with_flags(mjs, 50);
+        // js_delay_with_flags(mjs, 50);
     }
 
     // Release the ALT key
     furi_hal_hid_kb_release(KEY_MOD_LEFT_ALT);
-    js_delay_with_flags(mjs, 50);
+    // js_delay_with_flags(mjs, 50);
 
     return true; // Indicate success
 }

--- a/applications/system/js_app/modules/js_badusb.c
+++ b/applications/system/js_app/modules/js_badusb.c
@@ -412,20 +412,24 @@ static void js_badusb_altPrintln(struct mjs* mjs) {
     for(size_t i = 0; i < str_len; ++i) {
         uint8_t ascii_code = (uint8_t)str[i];
         
-        // Convert each character's ASCII code to a series of Numpad key presses with ALT key
-        char ascii_str[5]; // Enough to hold up to 4 digits plus a null terminator
+        // Convert the ASCII code of each character into a string of digits
+        char ascii_str[5]; // Sufficient to hold up to 4 digits plus a null terminator
         snprintf(ascii_str, sizeof(ascii_str), "%u", ascii_code);
 
-        // For each digit of the ASCII code, simulate pressing ALT + Numpad key
-        furi_hal_hid_kb_press(KEY_MOD_LEFT_ALT);
         for(size_t j = 0; ascii_str[j] != '\0'; ++j) {
-            uint16_t keycode = get_keycode_by_name((const char[]){"NUMPAD_", ascii_str[j], '\0'}, 3);
+            // Construct the keycode name string for the current digit
+            char keycode_name[11]; // "NUMPAD_" + one digit + '\0'
+            snprintf(keycode_name, sizeof(keycode_name), "NUMPAD_%c", ascii_str[j]);
+
+            // Find the corresponding keycode for the Numpad key
+            uint16_t keycode = get_keycode_by_name(keycode_name, strlen(keycode_name));
             if(keycode != HID_KEYBOARD_NONE) {
-                furi_hal_hid_kb_press(keycode);  // Press the Numpad key
-                furi_hal_hid_kb_release(keycode);  // Release the Numpad key
+                furi_hal_hid_kb_press(KEY_MOD_LEFT_ALT);  // Press the ALT key
+                furi_hal_hid_kb_press(keycode);           // Press the Numpad key
+                furi_hal_hid_kb_release(keycode);         // Release the Numpad key
+                furi_hal_hid_kb_release(KEY_MOD_LEFT_ALT); // Release the ALT key
             }
         }
-        furi_hal_hid_kb_release(KEY_MOD_LEFT_ALT); // Release the ALT key after each character
     }
 
     // Simulate pressing the Enter key to mimic println behavior

--- a/applications/system/js_app/modules/js_badusb.c
+++ b/applications/system/js_app/modules/js_badusb.c
@@ -402,7 +402,7 @@ static void js_badusb_println(struct mjs* mjs) {
 static bool ducky_altchar(struct mjs* mjs, const char* ascii_code) {
     // Hold the ALT key
     furi_hal_hid_kb_press(KEY_MOD_LEFT_ALT);
-    js_delay_with_flags(mjs, 200);
+    js_delay_with_flags(mjs, 50);
 
     // Loop through each digit of the ASCII code and press the corresponding numpad key
     for(size_t i = 0; ascii_code[i] != '\0'; i++) {
@@ -413,14 +413,14 @@ static bool ducky_altchar(struct mjs* mjs, const char* ascii_code) {
             continue;
         }
         furi_hal_hid_kb_press(numpad_keycode);
-        js_delay_with_flags(mjs, 200);
+        js_delay_with_flags(mjs, 50);
         furi_hal_hid_kb_release(numpad_keycode);
-        js_delay_with_flags(mjs, 200);
+        js_delay_with_flags(mjs, 50);
     }
 
     // Release the ALT key
     furi_hal_hid_kb_release(KEY_MOD_LEFT_ALT);
-    js_delay_with_flags(mjs, 200);
+    js_delay_with_flags(mjs, 50);
 
     return true; // Indicate success
 }

--- a/applications/system/js_app/modules/js_badusb.c
+++ b/applications/system/js_app/modules/js_badusb.c
@@ -409,18 +409,25 @@ static void js_badusb_altPrintln(struct mjs* mjs) {
     size_t str_len;
     const char* str = mjs_get_string(mjs, &str_val, &str_len);
 
+    // Corrected part in the js_badusb_altPrintln function
     for(size_t i = 0; i < str_len; ++i) {
         uint8_t ascii_code = (uint8_t)str[i];
         // Simulating pressing the ALT key
         furi_hal_hid_kb_press(KEY_MOD_LEFT_ALT);
-        // Inputting the ASCII code numbers
-        char ascii_str[5];
-        snprintf(ascii_str, sizeof(ascii_str), "%u", ascii_code);
-        for(size_t j = 0; ascii_str[j] != '\0'; ++j) {
-            uint16_t numpad_keycode = get_keycode_by_name((const char[]){'NUMPAD_', ascii_str[j], '\0'}, 3);
+        // Preparing to input the ASCII code numbers
+        char numpad_sequence[16]; // Adjust to a larger array size to accommodate the complete string
+
+        // For each character's ASCII code, convert it to a string with NUMPAD_ prefix
+        int num_digits = snprintf(NULL, 0, "%u", ascii_code); // Determine the number of digits in the ASCII code
+        snprintf(numpad_sequence, sizeof(numpad_sequence), "NUMPAD_%u", ascii_code); // Construct the string for numpad sequence
+        
+        // For each digit in the constructed NUMPAD_ string, find the corresponding keycode and simulate key press
+        for(int digit_index = 7; digit_index < 7 + num_digits; ++digit_index) {
+            char digit_str[2] = {numpad_sequence[digit_index], '\0'}; // Create a string for each digit
+            uint16_t numpad_keycode = get_keycode_by_name(digit_str, 1); // Get the keycode for the digit
             if(numpad_keycode != HID_KEYBOARD_NONE) {
-                furi_hal_hid_kb_press(numpad_keycode);
-                furi_hal_hid_kb_release(numpad_keycode);
+                furi_hal_hid_kb_press(numpad_keycode); // Press the digit key
+                furi_hal_hid_kb_release(numpad_keycode); // Release the digit key
             }
         }
         // Releasing the ALT key

--- a/applications/system/js_app/modules/js_badusb.c
+++ b/applications/system/js_app/modules/js_badusb.c
@@ -493,6 +493,8 @@ static void* js_badusb_create(struct mjs* mjs, mjs_val_t* object) {
     mjs_set(mjs, badusb_obj, "release", ~0, MJS_MK_FN(js_badusb_release));
     mjs_set(mjs, badusb_obj, "print", ~0, MJS_MK_FN(js_badusb_print));
     mjs_set(mjs, badusb_obj, "println", ~0, MJS_MK_FN(js_badusb_println));
+    // Register the altPrint method for calling from JavaScript
+    mjs_set(mjs, badusb_obj, "altPrint", ~0, MJS_MK_FN(js_badusb_altPrint));
     // Register the altPrintln method for calling from JavaScript
     mjs_set(mjs, badusb_obj, "altPrintln", ~0, MJS_MK_FN(js_badusb_altPrintln));
     *object = badusb_obj;

--- a/applications/system/js_app/modules/js_badusb.c
+++ b/applications/system/js_app/modules/js_badusb.c
@@ -52,6 +52,17 @@ static const struct {
     {"F10", HID_KEYBOARD_F10},
     {"F11", HID_KEYBOARD_F11},
     {"F12", HID_KEYBOARD_F12},
+
+    {"NUMPAD_0", HID_KEYPAD_0},
+    {"NUMPAD_1", HID_KEYPAD_1},
+    {"NUMPAD_2", HID_KEYPAD_2},
+    {"NUMPAD_3", HID_KEYPAD_3},
+    {"NUMPAD_4", HID_KEYPAD_4},
+    {"NUMPAD_5", HID_KEYPAD_5},
+    {"NUMPAD_6", HID_KEYPAD_6},
+    {"NUMPAD_7", HID_KEYPAD_7},
+    {"NUMPAD_8", HID_KEYPAD_8},
+    {"NUMPAD_9", HID_KEYPAD_9},
 };
 
 static void js_badusb_quit_free(JsBadusbInst* badusb) {

--- a/applications/system/js_app/modules/js_badusb.c
+++ b/applications/system/js_app/modules/js_badusb.c
@@ -432,7 +432,7 @@ static void alt_numpad_type_character(struct mjs* mjs, char character) {
     ducky_altchar(mjs, ascii_str);
 }
 
-// Function to simulate typing text using ALT key + Numpad ASCII code without adding a newline at the end
+// Correctly defined js_badusb_altPrint function
 static void js_badusb_altPrint(struct mjs* mjs) {
     mjs_val_t obj_string = mjs_arg(mjs, 0);
     if (!mjs_is_string(obj_string)) {
@@ -448,16 +448,6 @@ static void js_badusb_altPrint(struct mjs* mjs) {
     }
 
     mjs_return(mjs, MJS_UNDEFINED);
-}
-
-// Updated js_badusb_altPrintln function, now simply calls js_badusb_altPrint for the text part
-static void js_badusb_altPrintln(struct mjs* mjs) {
-    // First, print the text without a newline
-    js_badusb_altPrint(mjs);
-
-    // Then, simulate pressing the ENTER key to add a newline
-    furi_hal_hid_kb_press(HID_KEYBOARD_RETURN);
-    furi_hal_hid_kb_release(HID_KEYBOARD_RETURN);
 }
 
 static void js_badusb_altPrintln(struct mjs* mjs) {

--- a/applications/system/js_app/modules/js_badusb.c
+++ b/applications/system/js_app/modules/js_badusb.c
@@ -406,8 +406,12 @@ static bool ducky_altchar(struct mjs* mjs, const char* ascii_code) {
 
     // Loop through each digit of the ASCII code and press the corresponding numpad key
     for(size_t i = 0; ascii_code[i] != '\0'; i++) {
-        char digit = ascii_code[i] - '0'; // Convert char to digit
-        uint16_t numpad_keycode = get_keycode_by_digit(digit);
+        char digitChar[5] = {'N', 'U', 'M', ascii_code[i], '\0'}; // Construct the numpad key name
+        uint16_t numpad_keycode = get_keycode_by_name(digitChar, strlen(digitChar));
+        if(numpad_keycode == HID_KEYBOARD_NONE) {
+            // Handle error or unsupported keycode
+            continue;
+        }
         furi_hal_hid_kb_press(numpad_keycode);
         js_delay_with_flags(mjs, 200);
         furi_hal_hid_kb_release(numpad_keycode);

--- a/applications/system/js_app/modules/js_badusb.c
+++ b/applications/system/js_app/modules/js_badusb.c
@@ -399,31 +399,33 @@ static void js_badusb_println(struct mjs* mjs) {
     badusb_print(mjs, true);
 }
 
-// Simulates typing a character using the ALT key and Numpad ASCII code
-static void alt_numpad_type_character(struct mjs* mjs, char character) {
-    const uint32_t delay_ms = 200; // Example delay
-
-    // Press and hold the ALT key
+static bool ducky_altchar(struct mjs* mjs, const char* ascii_code) {
+    // Hold the ALT key
     furi_hal_hid_kb_press(KEY_MOD_LEFT_ALT);
-    js_delay_with_flags(mjs, delay_ms);
+    js_delay_with_flags(mjs, 200);
 
-    // Convert the character to its ASCII value and then to a string
-    char ascii_str[4];
-    snprintf(ascii_str, sizeof(ascii_str), "%03d", character);
-
-    // For each digit in the ASCII string, press and release the corresponding numpad key
-    for(size_t i = 0; ascii_str[i] != '\0'; i++) {
-        char digitStr[2] = {ascii_str[i], '\0'};
-        uint16_t numpad_keycode = get_keycode_by_name(digitStr, 1);
+    // Loop through each digit of the ASCII code and press the corresponding numpad key
+    for(size_t i = 0; ascii_code[i] != '\0'; i++) {
+        char digit = ascii_code[i] - '0'; // Convert char to digit
+        uint16_t numpad_keycode = get_keycode_by_digit(digit);
         furi_hal_hid_kb_press(numpad_keycode);
-        js_delay_with_flags(mjs, delay_ms);
+        js_delay_with_flags(mjs, 200);
         furi_hal_hid_kb_release(numpad_keycode);
-        js_delay_with_flags(mjs, delay_ms);
+        js_delay_with_flags(mjs, 200);
     }
 
     // Release the ALT key
     furi_hal_hid_kb_release(KEY_MOD_LEFT_ALT);
-    js_delay_with_flags(mjs, delay_ms);
+    js_delay_with_flags(mjs, 200);
+
+    return true; // Indicate success
+}
+
+static void alt_numpad_type_character(struct mjs* mjs, char character) {
+    char ascii_str[4];
+    snprintf(ascii_str, sizeof(ascii_str), "%u", (unsigned char)character);
+
+    ducky_altchar(mjs, ascii_str);
 }
 
 static void js_badusb_altPrintln(struct mjs* mjs) {

--- a/applications/system/js_app/modules/js_badusb.c
+++ b/applications/system/js_app/modules/js_badusb.c
@@ -52,7 +52,7 @@ static const struct {
     {"F10", HID_KEYBOARD_F10},
     {"F11", HID_KEYBOARD_F11},
     {"F12", HID_KEYBOARD_F12},
-    
+
     {"NUM0", HID_KEYPAD_0},
     {"NUM1", HID_KEYPAD_1},
     {"NUM2", HID_KEYPAD_2},
@@ -325,7 +325,35 @@ static void js_badusb_release(struct mjs* mjs) {
     mjs_return(mjs, MJS_UNDEFINED);
 }
 
-static void badusb_print(struct mjs* mjs, bool ln) {
+// Make sure NUMLOCK is enabled for altchar
+static void ducky_numlock_on() {
+    if((furi_hal_hid_get_led_state() & HID_KB_LED_NUM) == 0) {
+        furi_hal_hid_kb_press(HID_KEYBOARD_LOCK_NUM_LOCK);
+        furi_hal_hid_kb_release(HID_KEYBOARD_LOCK_NUM_LOCK);
+    }
+}
+
+// Simulate pressing a character using ALT+Numpad ASCII code
+static void ducky_altchar(const char* ascii_code) {
+    // Hold the ALT key
+    furi_hal_hid_kb_press(KEY_MOD_LEFT_ALT);
+
+    // Press the corresponding numpad key for each digit of the ASCII code
+    for(size_t i = 0; ascii_code[i] != '\0'; i++) {
+        char digitChar[5] = {'N', 'U', 'M', ascii_code[i], '\0'}; // Construct the numpad key name
+        uint16_t numpad_keycode = get_keycode_by_name(digitChar, strlen(digitChar));
+        if(numpad_keycode == HID_KEYBOARD_NONE) {
+            continue; // Skip if keycode not found
+        }
+        furi_hal_hid_kb_press(numpad_keycode);
+        furi_hal_hid_kb_release(numpad_keycode);
+    }
+
+    // Release the ALT key
+    furi_hal_hid_kb_release(KEY_MOD_LEFT_ALT);
+}
+
+static void badusb_print(struct mjs* mjs, bool ln, bool alt) {
     mjs_val_t obj_inst = mjs_get(mjs, mjs_get_this(mjs), INST_PROP_NAME, ~0);
     JsBadusbInst* badusb = mjs_get_ptr(mjs, obj_inst);
     furi_assert(badusb);
@@ -371,10 +399,20 @@ static void badusb_print(struct mjs* mjs, bool ln) {
         return;
     }
 
+    if(alt) {
+        ducky_numlock_on();
+    }
     for(size_t i = 0; i < text_len; i++) {
-        uint16_t keycode = HID_ASCII_TO_KEY(text_str[i]);
-        furi_hal_hid_kb_press(keycode);
-        furi_hal_hid_kb_release(keycode);
+        if(alt) {
+            // Convert character to ascii numeric value
+            char ascii_str[4];
+            snprintf(ascii_str, sizeof(ascii_str), "%u", (uint8_t)text_str[i]);
+            ducky_altchar(ascii_str);
+        } else {
+            uint16_t keycode = HID_ASCII_TO_KEY(text_str[i]);
+            furi_hal_hid_kb_press(keycode);
+            furi_hal_hid_kb_release(keycode);
+        }
         if(delay_val > 0) {
             bool need_exit = js_delay_with_flags(mjs, delay_val);
             if(need_exit) {
@@ -392,77 +430,19 @@ static void badusb_print(struct mjs* mjs, bool ln) {
 }
 
 static void js_badusb_print(struct mjs* mjs) {
-    badusb_print(mjs, false);
+    badusb_print(mjs, false, false);
 }
 
 static void js_badusb_println(struct mjs* mjs) {
-    badusb_print(mjs, true);
+    badusb_print(mjs, true, false);
 }
 
-// Simulate pressing a character using ALT+Numpad ASCII code
-static bool ducky_altchar(struct mjs* mjs, const char* ascii_code) {
-    (void)mjs; // Mark the mjs parameter as unused
-    // Hold the ALT key
-    furi_hal_hid_kb_press(KEY_MOD_LEFT_ALT);
-
-    // Press the corresponding numpad key for each digit of the ASCII code
-    for(size_t i = 0; ascii_code[i] != '\0'; i++) {
-        char digitChar[5] = {'N', 'U', 'M', ascii_code[i], '\0'}; // Construct the numpad key name
-        uint16_t numpad_keycode = get_keycode_by_name(digitChar, strlen(digitChar));
-        if(numpad_keycode == HID_KEYBOARD_NONE) {
-            continue; // Skip if keycode not found
-        }
-        furi_hal_hid_kb_press(numpad_keycode);
-        furi_hal_hid_kb_release(numpad_keycode);
-    }
-
-    // Release the ALT key
-    furi_hal_hid_kb_release(KEY_MOD_LEFT_ALT);
-
-    return true;
+static void js_badusb_alt_print(struct mjs* mjs) {
+    badusb_print(mjs, false, true);
 }
 
-// Type a character using the ALT+Numpad method and apply delay between characters
-static void alt_numpad_type_character(struct mjs* mjs, char character, uint32_t delay_ms) {
-    char ascii_str[4];
-    snprintf(ascii_str, sizeof(ascii_str), "%u", (unsigned char)character);
-    ducky_altchar(mjs, ascii_str);
-    js_delay_with_flags(mjs, delay_ms); // Apply delay between characters
-}
-
-// Handles the text input and decides whether to add a newline at the end, including character delays
-static void altPrint(struct mjs* mjs, bool ln) {
-    size_t text_len = 0;
-    uint32_t delay_ms = 0; // Initialize delay to 0 ms
-    mjs_val_t obj_string = mjs_arg(mjs, 0);
-    const char* text = mjs_get_string(mjs, &obj_string, &text_len);
-
-    if (mjs_nargs(mjs) == 2) {
-        // If delay is specified as the second argument
-        delay_ms = (uint32_t)mjs_get_int32(mjs, mjs_arg(mjs, 1));
-    }
-
-    for (size_t i = 0; i < text_len; ++i) {
-        alt_numpad_type_character(mjs, text[i], delay_ms);
-    }
-
-    if (ln) {
-        // Simulate pressing the ENTER key at the end if needed
-        furi_hal_hid_kb_press(HID_KEYBOARD_RETURN);
-        furi_hal_hid_kb_release(HID_KEYBOARD_RETURN);
-    }
-
-    mjs_return(mjs, MJS_UNDEFINED);
-}
-
-// Wrapper function for altPrint without newline
-static void js_badusb_altPrint(struct mjs* mjs) {
-    altPrint(mjs, false);
-}
-
-// Wrapper function for altPrint with newline
-static void js_badusb_altPrintln(struct mjs* mjs) {
-    altPrint(mjs, true);
+static void js_badusb_alt_println(struct mjs* mjs) {
+    badusb_print(mjs, true, true);
 }
 
 static void* js_badusb_create(struct mjs* mjs, mjs_val_t* object) {
@@ -477,10 +457,8 @@ static void* js_badusb_create(struct mjs* mjs, mjs_val_t* object) {
     mjs_set(mjs, badusb_obj, "release", ~0, MJS_MK_FN(js_badusb_release));
     mjs_set(mjs, badusb_obj, "print", ~0, MJS_MK_FN(js_badusb_print));
     mjs_set(mjs, badusb_obj, "println", ~0, MJS_MK_FN(js_badusb_println));
-    // Register the altPrint method for calling from JavaScript
-    mjs_set(mjs, badusb_obj, "altPrint", ~0, MJS_MK_FN(js_badusb_altPrint));
-    // Register the altPrintln method for calling from JavaScript
-    mjs_set(mjs, badusb_obj, "altPrintln", ~0, MJS_MK_FN(js_badusb_altPrintln));
+    mjs_set(mjs, badusb_obj, "altPrint", ~0, MJS_MK_FN(js_badusb_alt_print));
+    mjs_set(mjs, badusb_obj, "altPrintln", ~0, MJS_MK_FN(js_badusb_alt_println));
     *object = badusb_obj;
     return badusb;
 }

--- a/applications/system/js_app/modules/js_badusb.c
+++ b/applications/system/js_app/modules/js_badusb.c
@@ -432,6 +432,34 @@ static void alt_numpad_type_character(struct mjs* mjs, char character) {
     ducky_altchar(mjs, ascii_str);
 }
 
+// Function to simulate typing text using ALT key + Numpad ASCII code without adding a newline at the end
+static void js_badusb_altPrint(struct mjs* mjs) {
+    mjs_val_t obj_string = mjs_arg(mjs, 0);
+    if (!mjs_is_string(obj_string)) {
+        mjs_prepend_errorf(mjs, MJS_BAD_ARGS_ERROR, "Expected a string argument");
+        mjs_return(mjs, MJS_UNDEFINED);
+        return;
+    }
+
+    size_t text_len;
+    const char* text = mjs_get_string(mjs, &obj_string, &text_len);
+    for (size_t i = 0; i < text_len; ++i) {
+        alt_numpad_type_character(mjs, text[i]);
+    }
+
+    mjs_return(mjs, MJS_UNDEFINED);
+}
+
+// Updated js_badusb_altPrintln function, now simply calls js_badusb_altPrint for the text part
+static void js_badusb_altPrintln(struct mjs* mjs) {
+    // First, print the text without a newline
+    js_badusb_altPrint(mjs);
+
+    // Then, simulate pressing the ENTER key to add a newline
+    furi_hal_hid_kb_press(HID_KEYBOARD_RETURN);
+    furi_hal_hid_kb_release(HID_KEYBOARD_RETURN);
+}
+
 static void js_badusb_altPrintln(struct mjs* mjs) {
     mjs_val_t obj_string = mjs_arg(mjs, 0);
     if (!mjs_is_string(obj_string)) {


### PR DESCRIPTION
# What's new

This PR implements the addition of Numpad keybindings in js_badusb.c, addressing the feature request (#30). The implementation allows users to use ALT+Numpad combinations for input, enhancing functionality for non-US input methods.

Implemented changes include:
- Added keybindings for HID_KEYPAD_0 to HID_KEYPAD_9.
- Updated the sendStringViaAltNumpad function to support these keybindings.

# For the reviewer

This update is in response to the previously discussed feature request #30. The modifications are intended to improve the firmware's usability for non-US layouts by allowing ALT+Numpad combinations for text input.

- [x] I've uploaded the firmware with this patch to a device and verified its functionality.
- [x] I've confirmed the feature to be stable and the bug to be fixed with these changes.

Reference to the original feature request for more context:
- Addition of Numpad Keybindings in js_badusb.c #30

Please review the changes and consider merging this PR to enhance the project's functionality. Thank you for your consideration.