### PR TITLE
JS: Add __filepath and __dirpath globals.

### DIFF
--- a/applications/system/js_app/examples/apps/Scripts/path.js
+++ b/applications/system/js_app/examples/apps/Scripts/path.js
@@ -1,0 +1,9 @@
+let storage = require("storage");
+
+print("script has __dirpath of" + __dirpath);
+print("script has __filepath of" + __filepath);
+if (storage.exists(__dirpath + "/math.js")) {
+    print("math.js exist here.");
+} else {
+    print("math.js does not exist here.");
+}

--- a/applications/system/js_app/js_thread.c
+++ b/applications/system/js_app/js_thread.c
@@ -1,4 +1,5 @@
 #include <common/cs_dbg.h>
+#include <toolbox/path.h>
 #include <toolbox/stream/file_stream.h>
 #include <loader/firmware_api/firmware_api.h>
 #include <flipper_application/api_hashtable/api_hashtable.h>
@@ -319,6 +320,24 @@ static int32_t js_thread(void* arg) {
     struct mjs* mjs = mjs_create(worker);
     worker->modules = js_modules_create(mjs, worker->resolver);
     mjs_val_t global = mjs_get_global(mjs);
+    if(worker->path) {
+        FuriString* dirpath = furi_string_alloc();
+        path_extract_dirname(furi_string_get_cstr(worker->path), dirpath);
+        mjs_set(
+            mjs,
+            global,
+            "__filepath",
+            ~0,
+            mjs_mk_string(
+                mjs, furi_string_get_cstr(worker->path), furi_string_size(worker->path), true));
+        mjs_set(
+            mjs,
+            global,
+            "__dirpath",
+            ~0,
+            mjs_mk_string(mjs, furi_string_get_cstr(dirpath), furi_string_size(dirpath), true));
+        furi_string_free(dirpath);
+    }
     mjs_set(mjs, global, "print", ~0, MJS_MK_FN(js_print));
     mjs_set(mjs, global, "delay", ~0, MJS_MK_FN(js_delay));
     mjs_set(mjs, global, "to_string", ~0, MJS_MK_FN(js_global_to_string));


### PR DESCRIPTION
# What's new

- This adds two new global variables to JavaScript files loaded by the js_app.  `__filepath` is the fully qualified path to the .js file (like "/ext/apps/Scripts/path.js").  `__dirpath` is the folder containing the .js file (like "/ext/apps/Scripts").

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable
