### PR TITLE
Explain RNG differences, Fix JS Math.random()

### DIFF
--- a/applications/system/js_app/modules/js_math.c
+++ b/applications/system/js_app/modules/js_math.c
@@ -211,7 +211,7 @@ void js_math_random(struct mjs* mjs) {
         mjs_return(mjs, MJS_UNDEFINED);
     }
     const uint32_t random_val = furi_hal_random_get();
-    double rnd = (double)random_val / RAND_MAX;
+    double rnd = (double)random_val / FURI_HAL_RANDOM_MAX;
     mjs_return(mjs, mjs_mk_number(mjs, rnd));
 }
 

--- a/targets/furi_hal_include/furi_hal_random.h
+++ b/targets/furi_hal_include/furi_hal_random.h
@@ -6,12 +6,16 @@
 extern "C" {
 #endif
 
+#define FURI_HAL_RANDOM_MAX 0xFFFFFFFF
+
 /** Initialize random subsystem */
 void furi_hal_random_init(void);
 
 /** Get random value
+ * furi_hal_random_get() gives up to FURI_HAL_RANDOM_MAX
+ * rand() and random() give up to RAND_MAX
  *
- * @return     random value
+ * @return     32 bit random value (up to FURI_HAL_RANDOM_MAX)
  */
 uint32_t furi_hal_random_get(void);
 


### PR DESCRIPTION
# What's new

- Explain differences between `furi_hal_random_get()` and `rand()`
- Add `FURI_HAL_RANDOM_MAX` define
- Fix JS `Math.random()` with `FURI_HAL_RANDOM_MAX`
- Fixes #61 

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable
