### PR TITLE
Storage: USB Mass Storage enhancement for setting volume label

### DIFF
--- a/applications/services/storage/storage.c
+++ b/applications/services/storage/storage.c
@@ -43,10 +43,12 @@ Storage* storage_app_alloc(void) {
     }
 
 #ifndef FURI_RAM_EXEC
-    storage_mnt_init(&app->storage[ST_MNT]);
     storage_int_init(&app->storage[ST_INT]);
 #endif
     storage_ext_init(&app->storage[ST_EXT]);
+#ifndef FURI_RAM_EXEC
+    storage_mnt_init(&app->storage[ST_MNT]);
+#endif
 
     // sd icon gui
     app->sd_gui.enabled = false;

--- a/applications/services/storage/storage_glue.c
+++ b/applications/services/storage/storage_glue.c
@@ -156,3 +156,9 @@ size_t storage_open_files_count(StorageData* storage) {
     size_t count = StorageFileList_size(storage->files);
     return count;
 }
+
+const char* storage_file_get_path(File* file, StorageData* storage) {
+    if(!storage_has_file(file, storage)) return "";
+    StorageFile* storage_file_ref = storage_get_file(file, storage);
+    return furi_string_get_cstr(storage_file_ref->path);
+}

--- a/applications/services/storage/storage_glue.c
+++ b/applications/services/storage/storage_glue.c
@@ -158,7 +158,7 @@ size_t storage_open_files_count(StorageData* storage) {
 }
 
 const char* storage_file_get_path(File* file, StorageData* storage) {
-    if(!storage_has_file(file, storage)) return "";
     StorageFile* storage_file_ref = storage_get_file(file, storage);
+    if(!storage_file_ref) return "";
     return furi_string_get_cstr(storage_file_ref->path);
 }

--- a/applications/services/storage/storage_glue.h
+++ b/applications/services/storage/storage_glue.h
@@ -35,6 +35,7 @@ void storage_file_init(StorageFile* obj);
 void storage_file_init_set(StorageFile* obj, const StorageFile* src);
 void storage_file_set(StorageFile* obj, const StorageFile* src);
 void storage_file_clear(StorageFile* obj);
+const char* storage_file_get_path(File* file, StorageData* storage);
 
 void storage_data_init(StorageData* storage);
 StorageStatus storage_data_status(StorageData* storage);

--- a/applications/services/storage/storages/storage_ext.c
+++ b/applications/services/storage/storages/storage_ext.c
@@ -5,6 +5,7 @@
 #include <furi_hal.h>
 #include "sd_notify.h"
 #include <furi_hal_sd.h>
+#include <toolbox/path.h>
 
 typedef FIL SDFile;
 typedef DIR SDDir;
@@ -740,15 +741,22 @@ FS_Error storage_process_virtual_format(StorageData* storage) {
     SDData* sd_data = storage->data;
     uint8_t* work = malloc(_MAX_SS);
     SDError error = f_mkfs(sd_data->path, FM_ANY, 0, work, _MAX_SS);
-    storage_process_virtual_mount(storage);
-    const char* path = storage_file_get_path(mnt_image, mnt_image_storage);
-    const char* name = basename(path);
-    char label[strlen(name) - 3];
-    strlcpy(label, name, sizeof(label));
-    f_setlabel(label);
-    storage_process_virtual_unmount(storage);
     free(work);
     if(error != FR_OK) return FSE_INTERNAL;
+
+    if(storage_process_virtual_mount(storage) == FSE_OK) {
+        // Image file path
+        const char* img_path = storage_file_get_path(mnt_image, mnt_image_storage);
+        // Image file name
+        FuriString* img_name = furi_string_alloc();
+        path_extract_filename_no_ext(img_path, img_name);
+        // Label with drive id prefix
+        char* label = storage_ext_drive_path(storage, furi_string_get_cstr(img_name));
+        furi_string_free(img_name);
+        f_setlabel(label);
+        free(label);
+        storage_process_virtual_unmount(storage);
+    }
     return FSE_OK;
 #endif
 }

--- a/applications/services/storage/storages/storage_ext.c
+++ b/applications/services/storage/storages/storage_ext.c
@@ -1,6 +1,7 @@
 #include "fatfs.h"
 #include "../filesystem_api_internal.h"
 #include "storage_ext.h"
+#include "storage/storage_glue.h"
 #include <furi_hal.h>
 #include "sd_notify.h"
 #include <furi_hal_sd.h>
@@ -740,7 +741,11 @@ FS_Error storage_process_virtual_format(StorageData* storage) {
     uint8_t* work = malloc(_MAX_SS);
     SDError error = f_mkfs(sd_data->path, FM_ANY, 0, work, _MAX_SS);
     storage_process_virtual_mount(storage);
-    f_setlabel("DOLPHIN");
+    const char* path = storage_file_get_path(mnt_image, mnt_image_storage);
+    char* label = basename(path);
+    int len = strlen(label);
+    label[len - 4] = '\0'; // truncate the .img extension
+    f_setlabel(label);
     storage_process_virtual_unmount(storage);
     free(work);
     if(error != FR_OK) return FSE_INTERNAL;

--- a/applications/services/storage/storages/storage_ext.c
+++ b/applications/services/storage/storages/storage_ext.c
@@ -1,7 +1,6 @@
 #include "fatfs.h"
 #include "../filesystem_api_internal.h"
 #include "storage_ext.h"
-#include "storage/storage_glue.h"
 #include <furi_hal.h>
 #include "sd_notify.h"
 #include <furi_hal_sd.h>

--- a/applications/services/storage/storages/storage_ext.c
+++ b/applications/services/storage/storages/storage_ext.c
@@ -739,6 +739,9 @@ FS_Error storage_process_virtual_format(StorageData* storage) {
     SDData* sd_data = storage->data;
     uint8_t* work = malloc(_MAX_SS);
     SDError error = f_mkfs(sd_data->path, FM_ANY, 0, work, _MAX_SS);
+    storage_process_virtual_mount(storage);
+    f_setlabel("DOLPHIN");
+    storage_process_virtual_unmount(storage);
     free(work);
     if(error != FR_OK) return FSE_INTERNAL;
     return FSE_OK;

--- a/applications/services/storage/storages/storage_ext.c
+++ b/applications/services/storage/storages/storage_ext.c
@@ -742,9 +742,9 @@ FS_Error storage_process_virtual_format(StorageData* storage) {
     SDError error = f_mkfs(sd_data->path, FM_ANY, 0, work, _MAX_SS);
     storage_process_virtual_mount(storage);
     const char* path = storage_file_get_path(mnt_image, mnt_image_storage);
-    char* label = basename(path);
-    int len = strlen(label);
-    label[len - 4] = '\0'; // truncate the .img extension
+    const char* name = basename(path);
+    char label[strlen(name) - 3];
+    strlcpy(label, name, sizeof(label));
     f_setlabel(label);
     storage_process_virtual_unmount(storage);
     free(work);


### PR DESCRIPTION
# What's new

- Previously the default USB Mass Storage label was unset ("NO NAME"). Now, the label is set to the Image Name the user has input when the storage is created.

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality. Verified with all the latest dev changes as of April 6, 2024.
- [x] I've confirmed the bug to be fixed / feature to be stable. Created multiple volumes with a name and without (size gets set as name, thus the volume name as well).
