### PR TITLE
Favorite-able WAV files

### DIFF
--- a/applications/main/archive/helpers/archive_browser.h
+++ b/applications/main/archive/helpers/archive_browser.h
@@ -33,6 +33,7 @@ static const char* known_ext[] = {
     [ArchiveFileTypeSubghzRemote] = ".txt",
     [ArchiveFileTypeInfraredRemote] = ".txt",
     [ArchiveFileTypeBadKb] = ".txt",
+    [ArchiveFileTypeWAV] = ".wav",
     [ArchiveFileTypeU2f] = "?",
     [ArchiveFileTypeApplication] = ".fap",
     [ArchiveFileTypeJS] = ".js",

--- a/applications/main/archive/helpers/archive_files.h
+++ b/applications/main/archive/helpers/archive_files.h
@@ -19,6 +19,7 @@ typedef enum {
     ArchiveFileTypeSubghzRemote,
     ArchiveFileTypeInfraredRemote,
     ArchiveFileTypeBadKb,
+    ArchiveFileTypeWAV,
     ArchiveFileTypeU2f,
     ArchiveFileTypeApplication,
     ArchiveFileTypeJS,

--- a/applications/main/archive/scenes/archive_scene_browser.c
+++ b/applications/main/archive/scenes/archive_scene_browser.c
@@ -32,6 +32,8 @@ const char* archive_get_flipper_app_name(ArchiveFileTypeEnum file_type) {
         return EXT_PATH("apps/Infrared/ir_remote.fap");
     case ArchiveFileTypeBadKb:
         return "Bad KB";
+    case ArchiveFileTypeWAV:
+        return EXT_PATH("apps/Media/wav_player.fap");
     case ArchiveFileTypeU2f:
         return "U2F";
     case ArchiveFileTypeUpdateManifest:

--- a/applications/main/archive/views/archive_browser_view.c
+++ b/applications/main/archive/views/archive_browser_view.c
@@ -34,6 +34,7 @@ static const Icon* ArchiveItemIcons[] = {
     [ArchiveFileTypeSubghzRemote] = &I_subrem_10px,
     [ArchiveFileTypeInfraredRemote] = &I_ir_scope_10px,
     [ArchiveFileTypeBadKb] = &I_badkb_10px,
+    [ArchiveFileTypeWAV] = &I_music_10px,
     [ArchiveFileTypeU2f] = &I_u2f_10px,
     [ArchiveFileTypeApplication] = &I_Apps_10px,
     [ArchiveFileTypeJS] = &I_js_script_10px,


### PR DESCRIPTION
# What's new

Primarily just wanted this feature for the sake of favorite-ing the cart lock/unlock WAVs.

- Allows `archive` to recognize `.wav` files as openable by `wav_player`; as such enables "favorite" menu item 
- Makes basic edits to `wav_player` to allow "direct launching" from a file, rather than requiring a file browser dialog to select the file after starting the FAP.

The latter is messy / very quickly done as proof-of-concept. Doesn't yet impl the "favorite timeout" feature (have yet to use this myself so not actually sure what it does). Aside from that, anything missing that needs implementing to finalize this as a feature?

Given the required changes across both this repo and the submoduled apps repo, what's the best form for PR here? Shall I open a separate PR on the apps repo and reference the two?

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable
