### PR TITLE
JS: Fix widget sometimes MemCrash on exit.

### DIFF
--- a/applications/system/js_app/modules/js_widget.c
+++ b/applications/system/js_app/modules/js_widget.c
@@ -917,9 +917,8 @@ static void widget_remove_view(void* context) {
                 ComponentArray_it(it, model->component);
                 while(!ComponentArray_end_p(it)) {
                     WidgetComponent* component = *ComponentArray_ref(it);
-                    if(component->free) {
+                    if(component && component->free) {
                         component->free(component);
-                        component->free = NULL;
                     }
                     ComponentArray_next(it);
                 }
@@ -1003,6 +1002,7 @@ static void js_widget_destroy(void* inst) {
         view_dispatcher_stop(widget->view_dispatcher);
         widget_deinit(widget);
     }
+
     widget_remove_view(widget);
     free(widget);
 }


### PR DESCRIPTION
# What's new

- Bug fix where sometimes JavaScript scripts were crashing on exit if they used the JS widget feature.

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable
