### PR TITLE
Fix MNTM-DEV git hash formatting

### DIFF
--- a/applications/main/momentum_app/momentum_app.c
+++ b/applications/main/momentum_app/momentum_app.c
@@ -39,14 +39,12 @@ bool momentum_app_apply(MomentumApp* app) {
                    file, SUBGHZ_SETTING_FILE_TYPE, SUBGHZ_SETTING_FILE_VERSION))
                 break;
 
-            while(flipper_format_delete_key(file, "Add_standard_frequencies"))
-                ;
+            while(flipper_format_delete_key(file, "Add_standard_frequencies"));
             flipper_format_write_bool(
                 file, "Add_standard_frequencies", &app->subghz_use_defaults, 1);
 
             if(!flipper_format_rewind(file)) break;
-            while(flipper_format_delete_key(file, "Frequency"))
-                ;
+            while(flipper_format_delete_key(file, "Frequency"));
             FrequencyList_it(it, app->subghz_static_freqs);
             for(size_t i = 0; i < FrequencyList_size(app->subghz_static_freqs); i++) {
                 flipper_format_write_uint32(
@@ -54,8 +52,7 @@ bool momentum_app_apply(MomentumApp* app) {
             }
 
             if(!flipper_format_rewind(file)) break;
-            while(flipper_format_delete_key(file, "Hopper_frequency"))
-                ;
+            while(flipper_format_delete_key(file, "Hopper_frequency"));
             for(size_t i = 0; i < FrequencyList_size(app->subghz_hopper_freqs); i++) {
                 flipper_format_write_uint32(
                     file, "Hopper_frequency", FrequencyList_get(app->subghz_hopper_freqs, i), 1);
@@ -328,7 +325,8 @@ MomentumApp* momentum_app_alloc() {
     if(furi_string_start_with(app->version_tag, "mntm-dev")) {
         furi_string_set(app->version_tag, "MNTM-DEV  ");
         const char* sha = version_get_githash(NULL);
-        for(size_t i = 0; i < strlen(sha); ++i) {
+        const uint8_t sha_len = strlen(sha) <= 7 ? strlen(sha) : 7;
+        for(size_t i = 0; i < sha_len; ++i) {
             furi_string_push_back(app->version_tag, toupper(sha[i]));
         }
     } else {

--- a/applications/main/momentum_app/momentum_app.c
+++ b/applications/main/momentum_app/momentum_app.c
@@ -39,12 +39,14 @@ bool momentum_app_apply(MomentumApp* app) {
                    file, SUBGHZ_SETTING_FILE_TYPE, SUBGHZ_SETTING_FILE_VERSION))
                 break;
 
-            while(flipper_format_delete_key(file, "Add_standard_frequencies"));
+            while(flipper_format_delete_key(file, "Add_standard_frequencies"))
+                ;
             flipper_format_write_bool(
                 file, "Add_standard_frequencies", &app->subghz_use_defaults, 1);
 
             if(!flipper_format_rewind(file)) break;
-            while(flipper_format_delete_key(file, "Frequency"));
+            while(flipper_format_delete_key(file, "Frequency"))
+                ;
             FrequencyList_it(it, app->subghz_static_freqs);
             for(size_t i = 0; i < FrequencyList_size(app->subghz_static_freqs); i++) {
                 flipper_format_write_uint32(
@@ -52,7 +54,8 @@ bool momentum_app_apply(MomentumApp* app) {
             }
 
             if(!flipper_format_rewind(file)) break;
-            while(flipper_format_delete_key(file, "Hopper_frequency"));
+            while(flipper_format_delete_key(file, "Hopper_frequency"))
+                ;
             for(size_t i = 0; i < FrequencyList_size(app->subghz_hopper_freqs); i++) {
                 flipper_format_write_uint32(
                     file, "Hopper_frequency", FrequencyList_get(app->subghz_hopper_freqs, i), 1);

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -8,7 +8,7 @@ from flipper.app import App
 
 
 class GitVersion:
-    REVISION_SUFFIX_LENGTH = 8
+    REVISION_SUFFIX_LENGTH = 7
 
     def __init__(self, source_dir, suffix):
         self.source_dir = source_dir

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -8,7 +8,7 @@ from flipper.app import App
 
 
 class GitVersion:
-    REVISION_SUFFIX_LENGTH = 7
+    REVISION_SUFFIX_LENGTH = 8
 
     def __init__(self, source_dir, suffix):
         self.source_dir = source_dir


### PR DESCRIPTION
# What's new

For a (currently unknown) reason, the built `version.inc.h` `#define GIT_COMMIT` on my [dev branch commit cacdc68](https://github.com/zacharyweiss/Momentum-Firmware/tree/cacdc6841afa1fc3f21767b42f75bbb22606ddb2) was populated with the first 8 characters of the commit hash when built, rather than the standard first 7 characters. As a result, when displayed in `momentum_app_scene_start` the hash header spills over the edge of the screen. 

While I don't diagnose what causes the oddity in # chars of the built `GIT_COMMIT`, this PR adds a simple max `strlen` of 7 for the displayed hash. `strlen` still checked, in the event there are fewer than 7 chars.

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable
