### PR TITLE
Improve Hormann BiSecur readability in SubGHz history

### DIFF
--- a/applications/main/subghz/subghz_history.c
+++ b/applications/main/subghz/subghz_history.c
@@ -265,7 +265,6 @@ bool subghz_history_add_to_history(
     instance->code_last_hash_data = hash_data;
     instance->last_update_timestamp = furi_get_tick();
 
-    FuriString* text = furi_string_alloc();
     SubGhzHistoryItem* item = SubGhzHistoryItemArray_push_raw(instance->history->data);
     item->preset = malloc(sizeof(SubGhzRadioPreset));
     item->type = decoder_base->protocol->type;
@@ -284,6 +283,15 @@ bool subghz_history_add_to_history(
     item->item_str = furi_string_alloc();
     item->flipper_string = flipper_format_string_alloc();
     subghz_protocol_decoder_base_serialize(decoder_base, item->flipper_string, preset);
+
+    if(decoder_base->protocol && decoder_base->protocol->decoder &&
+       decoder_base->protocol->decoder->get_string_brief) {
+        decoder_base->protocol->decoder->get_string_brief(decoder_base, item->item_str);
+        instance->last_index_write++;
+        return true;
+    }
+
+    FuriString* text = furi_string_alloc();
 
     do {
         if(!flipper_format_rewind(item->flipper_string)) {

--- a/applications/main/subghz/subghz_history.c
+++ b/applications/main/subghz/subghz_history.c
@@ -245,7 +245,7 @@ bool subghz_history_add_to_history(
     SubGhzProtocolDecoderBase* decoder_base = context;
     uint32_t hash_data = subghz_protocol_decoder_base_get_hash_data_long(decoder_base);
     if((instance->code_last_hash_data == hash_data) &&
-       ((furi_get_tick() - instance->last_update_timestamp) < 500)) {
+       ((furi_get_tick() - instance->last_update_timestamp) < 600)) {
         instance->last_update_timestamp = furi_get_tick();
         return false;
     }

--- a/lib/subghz/protocols/acurite_592txr.c
+++ b/lib/subghz/protocols/acurite_592txr.c
@@ -72,6 +72,7 @@ const SubGhzProtocolDecoder ws_protocol_acurite_592txr_decoder = {
     .serialize = ws_protocol_decoder_acurite_592txr_serialize,
     .deserialize = ws_protocol_decoder_acurite_592txr_deserialize,
     .get_string = ws_protocol_decoder_acurite_592txr_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder ws_protocol_acurite_592txr_encoder = {

--- a/lib/subghz/protocols/acurite_606tx.c
+++ b/lib/subghz/protocols/acurite_606tx.c
@@ -55,6 +55,7 @@ const SubGhzProtocolDecoder ws_protocol_acurite_606tx_decoder = {
     .serialize = ws_protocol_decoder_acurite_606tx_serialize,
     .deserialize = ws_protocol_decoder_acurite_606tx_deserialize,
     .get_string = ws_protocol_decoder_acurite_606tx_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder ws_protocol_acurite_606tx_encoder = {

--- a/lib/subghz/protocols/acurite_609txc.c
+++ b/lib/subghz/protocols/acurite_609txc.c
@@ -56,6 +56,7 @@ const SubGhzProtocolDecoder ws_protocol_acurite_609txc_decoder = {
     .serialize = ws_protocol_decoder_acurite_609txc_serialize,
     .deserialize = ws_protocol_decoder_acurite_609txc_deserialize,
     .get_string = ws_protocol_decoder_acurite_609txc_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder ws_protocol_acurite_609txc_encoder = {

--- a/lib/subghz/protocols/acurite_986.c
+++ b/lib/subghz/protocols/acurite_986.c
@@ -62,6 +62,7 @@ const SubGhzProtocolDecoder ws_protocol_acurite_986_decoder = {
     .serialize = ws_protocol_decoder_acurite_986_serialize,
     .deserialize = ws_protocol_decoder_acurite_986_deserialize,
     .get_string = ws_protocol_decoder_acurite_986_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder ws_protocol_acurite_986_encoder = {

--- a/lib/subghz/protocols/alutech_at_4n.c
+++ b/lib/subghz/protocols/alutech_at_4n.c
@@ -59,6 +59,7 @@ const SubGhzProtocolDecoder subghz_protocol_alutech_at_4n_decoder = {
     .serialize = subghz_protocol_decoder_alutech_at_4n_serialize,
     .deserialize = subghz_protocol_decoder_alutech_at_4n_deserialize,
     .get_string = subghz_protocol_decoder_alutech_at_4n_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_alutech_at_4n_encoder = {

--- a/lib/subghz/protocols/ambient_weather.c
+++ b/lib/subghz/protocols/ambient_weather.c
@@ -70,6 +70,7 @@ const SubGhzProtocolDecoder ws_protocol_ambient_weather_decoder = {
     .serialize = ws_protocol_decoder_ambient_weather_serialize,
     .deserialize = ws_protocol_decoder_ambient_weather_deserialize,
     .get_string = ws_protocol_decoder_ambient_weather_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder ws_protocol_ambient_weather_encoder = {

--- a/lib/subghz/protocols/ansonic.c
+++ b/lib/subghz/protocols/ansonic.c
@@ -54,6 +54,7 @@ const SubGhzProtocolDecoder subghz_protocol_ansonic_decoder = {
     .serialize = subghz_protocol_decoder_ansonic_serialize,
     .deserialize = subghz_protocol_decoder_ansonic_deserialize,
     .get_string = subghz_protocol_decoder_ansonic_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_ansonic_encoder = {

--- a/lib/subghz/protocols/auriol_ahfl.c
+++ b/lib/subghz/protocols/auriol_ahfl.c
@@ -67,6 +67,7 @@ const SubGhzProtocolDecoder ws_protocol_auriol_ahfl_decoder = {
     .serialize = ws_protocol_decoder_auriol_ahfl_serialize,
     .deserialize = ws_protocol_decoder_auriol_ahfl_deserialize,
     .get_string = ws_protocol_decoder_auriol_ahfl_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder ws_protocol_auriol_ahfl_encoder = {

--- a/lib/subghz/protocols/auriol_hg0601a.c
+++ b/lib/subghz/protocols/auriol_hg0601a.c
@@ -66,6 +66,7 @@ const SubGhzProtocolDecoder ws_protocol_auriol_th_decoder = {
     .serialize = ws_protocol_decoder_auriol_th_serialize,
     .deserialize = ws_protocol_decoder_auriol_th_deserialize,
     .get_string = ws_protocol_decoder_auriol_th_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder ws_protocol_auriol_th_encoder = {

--- a/lib/subghz/protocols/bett.c
+++ b/lib/subghz/protocols/bett.c
@@ -64,6 +64,7 @@ const SubGhzProtocolDecoder subghz_protocol_bett_decoder = {
     .serialize = subghz_protocol_decoder_bett_serialize,
     .deserialize = subghz_protocol_decoder_bett_deserialize,
     .get_string = subghz_protocol_decoder_bett_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_bett_encoder = {

--- a/lib/subghz/protocols/bin_raw.c
+++ b/lib/subghz/protocols/bin_raw.c
@@ -101,6 +101,7 @@ const SubGhzProtocolDecoder subghz_protocol_bin_raw_decoder = {
     .serialize = subghz_protocol_decoder_bin_raw_serialize,
     .deserialize = subghz_protocol_decoder_bin_raw_deserialize,
     .get_string = subghz_protocol_decoder_bin_raw_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_bin_raw_encoder = {

--- a/lib/subghz/protocols/came.c
+++ b/lib/subghz/protocols/came.c
@@ -60,6 +60,7 @@ const SubGhzProtocolDecoder subghz_protocol_came_decoder = {
     .serialize = subghz_protocol_decoder_came_serialize,
     .deserialize = subghz_protocol_decoder_came_deserialize,
     .get_string = subghz_protocol_decoder_came_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_came_encoder = {

--- a/lib/subghz/protocols/came_atomo.c
+++ b/lib/subghz/protocols/came_atomo.c
@@ -51,6 +51,7 @@ const SubGhzProtocolDecoder subghz_protocol_came_atomo_decoder = {
     .serialize = subghz_protocol_decoder_came_atomo_serialize,
     .deserialize = subghz_protocol_decoder_came_atomo_deserialize,
     .get_string = subghz_protocol_decoder_came_atomo_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_came_atomo_encoder = {

--- a/lib/subghz/protocols/came_twee.c
+++ b/lib/subghz/protocols/came_twee.c
@@ -82,6 +82,7 @@ const SubGhzProtocolDecoder subghz_protocol_came_twee_decoder = {
     .serialize = subghz_protocol_decoder_came_twee_serialize,
     .deserialize = subghz_protocol_decoder_came_twee_deserialize,
     .get_string = subghz_protocol_decoder_came_twee_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_came_twee_encoder = {

--- a/lib/subghz/protocols/chamberlain_code.c
+++ b/lib/subghz/protocols/chamberlain_code.c
@@ -78,6 +78,7 @@ const SubGhzProtocolDecoder subghz_protocol_chamb_code_decoder = {
     .serialize = subghz_protocol_decoder_chamb_code_serialize,
     .deserialize = subghz_protocol_decoder_chamb_code_deserialize,
     .get_string = subghz_protocol_decoder_chamb_code_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_chamb_code_encoder = {

--- a/lib/subghz/protocols/clemsa.c
+++ b/lib/subghz/protocols/clemsa.c
@@ -63,6 +63,7 @@ const SubGhzProtocolDecoder subghz_protocol_clemsa_decoder = {
     .serialize = subghz_protocol_decoder_clemsa_serialize,
     .deserialize = subghz_protocol_decoder_clemsa_deserialize,
     .get_string = subghz_protocol_decoder_clemsa_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_clemsa_encoder = {

--- a/lib/subghz/protocols/doitrand.c
+++ b/lib/subghz/protocols/doitrand.c
@@ -55,6 +55,7 @@ const SubGhzProtocolDecoder subghz_protocol_doitrand_decoder = {
     .serialize = subghz_protocol_decoder_doitrand_serialize,
     .deserialize = subghz_protocol_decoder_doitrand_deserialize,
     .get_string = subghz_protocol_decoder_doitrand_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_doitrand_encoder = {

--- a/lib/subghz/protocols/dooya.c
+++ b/lib/subghz/protocols/dooya.c
@@ -49,6 +49,7 @@ const SubGhzProtocolDecoder subghz_protocol_dooya_decoder = {
     .serialize = subghz_protocol_decoder_dooya_serialize,
     .deserialize = subghz_protocol_decoder_dooya_deserialize,
     .get_string = subghz_protocol_decoder_dooya_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_dooya_encoder = {

--- a/lib/subghz/protocols/faac_slh.c
+++ b/lib/subghz/protocols/faac_slh.c
@@ -70,6 +70,7 @@ const SubGhzProtocolDecoder subghz_protocol_faac_slh_decoder = {
     .serialize = subghz_protocol_decoder_faac_slh_serialize,
     .deserialize = subghz_protocol_decoder_faac_slh_deserialize,
     .get_string = subghz_protocol_decoder_faac_slh_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_faac_slh_encoder = {

--- a/lib/subghz/protocols/gate_tx.c
+++ b/lib/subghz/protocols/gate_tx.c
@@ -48,6 +48,7 @@ const SubGhzProtocolDecoder subghz_protocol_gate_tx_decoder = {
     .serialize = subghz_protocol_decoder_gate_tx_serialize,
     .deserialize = subghz_protocol_decoder_gate_tx_deserialize,
     .get_string = subghz_protocol_decoder_gate_tx_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_gate_tx_encoder = {

--- a/lib/subghz/protocols/gt_wt_02.c
+++ b/lib/subghz/protocols/gt_wt_02.c
@@ -69,6 +69,7 @@ const SubGhzProtocolDecoder ws_protocol_gt_wt_02_decoder = {
     .serialize = ws_protocol_decoder_gt_wt_02_serialize,
     .deserialize = ws_protocol_decoder_gt_wt_02_deserialize,
     .get_string = ws_protocol_decoder_gt_wt_02_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder ws_protocol_gt_wt_02_encoder = {

--- a/lib/subghz/protocols/gt_wt_03.c
+++ b/lib/subghz/protocols/gt_wt_03.c
@@ -95,6 +95,7 @@ const SubGhzProtocolDecoder ws_protocol_gt_wt_03_decoder = {
     .serialize = ws_protocol_decoder_gt_wt_03_serialize,
     .deserialize = ws_protocol_decoder_gt_wt_03_deserialize,
     .get_string = ws_protocol_decoder_gt_wt_03_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder ws_protocol_gt_wt_03_encoder = {

--- a/lib/subghz/protocols/holtek.c
+++ b/lib/subghz/protocols/holtek.c
@@ -58,6 +58,7 @@ const SubGhzProtocolDecoder subghz_protocol_holtek_decoder = {
     .serialize = subghz_protocol_decoder_holtek_serialize,
     .deserialize = subghz_protocol_decoder_holtek_deserialize,
     .get_string = subghz_protocol_decoder_holtek_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_holtek_encoder = {

--- a/lib/subghz/protocols/holtek_ht12x.c
+++ b/lib/subghz/protocols/holtek_ht12x.c
@@ -65,6 +65,7 @@ const SubGhzProtocolDecoder subghz_protocol_holtek_th12x_decoder = {
     .serialize = subghz_protocol_decoder_holtek_th12x_serialize,
     .deserialize = subghz_protocol_decoder_holtek_th12x_deserialize,
     .get_string = subghz_protocol_decoder_holtek_th12x_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_holtek_th12x_encoder = {

--- a/lib/subghz/protocols/honeywell.c
+++ b/lib/subghz/protocols/honeywell.c
@@ -350,6 +350,7 @@ const SubGhzProtocolDecoder subghz_protocol_honeywell_decoder = {
     .serialize = subghz_protocol_decoder_honeywell_serialize,
     .deserialize = subghz_protocol_decoder_honeywell_deserialize,
     .get_string = subghz_protocol_decoder_honeywell_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_honeywell_encoder = {

--- a/lib/subghz/protocols/honeywell_wdb.c
+++ b/lib/subghz/protocols/honeywell_wdb.c
@@ -59,6 +59,7 @@ const SubGhzProtocolDecoder subghz_protocol_honeywell_wdb_decoder = {
     .serialize = subghz_protocol_decoder_honeywell_wdb_serialize,
     .deserialize = subghz_protocol_decoder_honeywell_wdb_deserialize,
     .get_string = subghz_protocol_decoder_honeywell_wdb_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_honeywell_wdb_encoder = {

--- a/lib/subghz/protocols/hormann.c
+++ b/lib/subghz/protocols/hormann.c
@@ -52,6 +52,7 @@ const SubGhzProtocolDecoder subghz_protocol_hormann_decoder = {
     .serialize = subghz_protocol_decoder_hormann_serialize,
     .deserialize = subghz_protocol_decoder_hormann_deserialize,
     .get_string = subghz_protocol_decoder_hormann_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_hormann_encoder = {

--- a/lib/subghz/protocols/hormann_bisecur.c
+++ b/lib/subghz/protocols/hormann_bisecur.c
@@ -63,7 +63,7 @@ const SubGhzProtocolDecoder subghz_protocol_hormann_bisecur_decoder = {
     .serialize = subghz_protocol_decoder_hormann_bisecur_serialize,
     .deserialize = subghz_protocol_decoder_hormann_bisecur_deserialize,
     .get_string = subghz_protocol_decoder_hormann_bisecur_get_string,
-    .get_string_brief = NULL,
+    .get_string_brief = subghz_protocol_decoder_hormann_bisecur_get_string_brief,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_hormann_bisecur_encoder = {
@@ -571,6 +571,25 @@ void subghz_protocol_decoder_hormann_bisecur_get_string(void* context, FuriStrin
         instance->generic.serial,
         instance->generic.data,
         instance->generic.data_2);
+}
+
+void subghz_protocol_decoder_hormann_bisecur_get_string_brief(void* context, FuriString* output) {
+    furi_assert(context);
+    SubGhzProtocolDecoderHormannBiSecur* instance = context;
+    subghz_protocol_hormann_bisecur_parse_data(instance);
+    bool valid_crc = subghz_protocol_decoder_hormann_bisecur_check_crc(instance);
+
+    if(!valid_crc) {
+        furi_string_cat_printf(output, "HBS Bad checksum");
+        return;
+    }
+
+    uint8_t data_hash = subghz_protocol_blocks_xor_bytes(
+        (const uint8_t*)&instance->generic.data, sizeof(uint64_t));
+    data_hash ^= subghz_protocol_blocks_xor_bytes(
+        (const uint8_t*)&instance->generic.data_2, sizeof(uint64_t));
+
+    furi_string_cat_printf(output, "HBS %08lX:%02X", instance->generic.serial, data_hash);
 }
 
 static LevelDuration subghz_protocol_encoder_hormann_bisecur_add_duration_to_upload(

--- a/lib/subghz/protocols/hormann_bisecur.c
+++ b/lib/subghz/protocols/hormann_bisecur.c
@@ -63,6 +63,7 @@ const SubGhzProtocolDecoder subghz_protocol_hormann_bisecur_decoder = {
     .serialize = subghz_protocol_decoder_hormann_bisecur_serialize,
     .deserialize = subghz_protocol_decoder_hormann_bisecur_deserialize,
     .get_string = subghz_protocol_decoder_hormann_bisecur_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_hormann_bisecur_encoder = {

--- a/lib/subghz/protocols/hormann_bisecur.c
+++ b/lib/subghz/protocols/hormann_bisecur.c
@@ -586,10 +586,11 @@ void subghz_protocol_decoder_hormann_bisecur_get_string_brief(void* context, Fur
 
     uint8_t data_hash = subghz_protocol_blocks_xor_bytes(
         (const uint8_t*)&instance->generic.data, sizeof(uint64_t));
-    data_hash ^= subghz_protocol_blocks_xor_bytes(
+    uint8_t data_2_hash = subghz_protocol_blocks_xor_bytes(
         (const uint8_t*)&instance->generic.data_2, sizeof(uint64_t));
 
-    furi_string_cat_printf(output, "HBS %08lX:%02X", instance->generic.serial, data_hash);
+    furi_string_cat_printf(
+        output, "HBS %08lX:%02X%02X", instance->generic.serial, data_hash, data_2_hash);
 }
 
 static LevelDuration subghz_protocol_encoder_hormann_bisecur_add_duration_to_upload(

--- a/lib/subghz/protocols/hormann_bisecur.h
+++ b/lib/subghz/protocols/hormann_bisecur.h
@@ -109,3 +109,10 @@ SubGhzProtocolStatus subghz_protocol_decoder_hormann_bisecur_deserialize(
  * @param output Resulting text
  */
 void subghz_protocol_decoder_hormann_bisecur_get_string(void* context, FuriString* output);
+
+/**
+ * Getting a one-line textual representation of the received data.
+ * @param context Pointer to a SubGhzProtocolDecoderHormannBiSecur instance
+ * @param output Resulting text
+ */
+void subghz_protocol_decoder_hormann_bisecur_get_string_brief(void* context, FuriString* output);

--- a/lib/subghz/protocols/ido.c
+++ b/lib/subghz/protocols/ido.c
@@ -48,6 +48,7 @@ const SubGhzProtocolDecoder subghz_protocol_ido_decoder = {
     .deserialize = subghz_protocol_decoder_ido_deserialize,
     .serialize = subghz_protocol_decoder_ido_serialize,
     .get_string = subghz_protocol_decoder_ido_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_ido_encoder = {

--- a/lib/subghz/protocols/infactory.c
+++ b/lib/subghz/protocols/infactory.c
@@ -80,6 +80,7 @@ const SubGhzProtocolDecoder ws_protocol_infactory_decoder = {
     .serialize = ws_protocol_decoder_infactory_serialize,
     .deserialize = ws_protocol_decoder_infactory_deserialize,
     .get_string = ws_protocol_decoder_infactory_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder ws_protocol_infactory_encoder = {

--- a/lib/subghz/protocols/intertechno_v3.c
+++ b/lib/subghz/protocols/intertechno_v3.c
@@ -57,6 +57,7 @@ const SubGhzProtocolDecoder subghz_protocol_intertechno_v3_decoder = {
     .serialize = subghz_protocol_decoder_intertechno_v3_serialize,
     .deserialize = subghz_protocol_decoder_intertechno_v3_deserialize,
     .get_string = subghz_protocol_decoder_intertechno_v3_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_intertechno_v3_encoder = {

--- a/lib/subghz/protocols/kedsum_th.c
+++ b/lib/subghz/protocols/kedsum_th.c
@@ -66,6 +66,7 @@ const SubGhzProtocolDecoder ws_protocol_kedsum_th_decoder = {
     .serialize = ws_protocol_decoder_kedsum_th_serialize,
     .deserialize = ws_protocol_decoder_kedsum_th_deserialize,
     .get_string = ws_protocol_decoder_kedsum_th_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder ws_protocol_kedsum_th_encoder = {

--- a/lib/subghz/protocols/keeloq.c
+++ b/lib/subghz/protocols/keeloq.c
@@ -66,6 +66,7 @@ const SubGhzProtocolDecoder subghz_protocol_keeloq_decoder = {
     .serialize = subghz_protocol_decoder_keeloq_serialize,
     .deserialize = subghz_protocol_decoder_keeloq_deserialize,
     .get_string = subghz_protocol_decoder_keeloq_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_keeloq_encoder = {

--- a/lib/subghz/protocols/kia.c
+++ b/lib/subghz/protocols/kia.c
@@ -50,6 +50,7 @@ const SubGhzProtocolDecoder subghz_protocol_kia_decoder = {
     .serialize = subghz_protocol_decoder_kia_serialize,
     .deserialize = subghz_protocol_decoder_kia_deserialize,
     .get_string = subghz_protocol_decoder_kia_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_kia_encoder = {

--- a/lib/subghz/protocols/kinggates_stylo_4k.c
+++ b/lib/subghz/protocols/kinggates_stylo_4k.c
@@ -55,6 +55,7 @@ const SubGhzProtocolDecoder subghz_protocol_kinggates_stylo_4k_decoder = {
     .serialize = subghz_protocol_decoder_kinggates_stylo_4k_serialize,
     .deserialize = subghz_protocol_decoder_kinggates_stylo_4k_deserialize,
     .get_string = subghz_protocol_decoder_kinggates_stylo_4k_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_kinggates_stylo_4k_encoder = {

--- a/lib/subghz/protocols/lacrosse_tx.c
+++ b/lib/subghz/protocols/lacrosse_tx.c
@@ -84,6 +84,7 @@ const SubGhzProtocolDecoder ws_protocol_lacrosse_tx_decoder = {
     .serialize = ws_protocol_decoder_lacrosse_tx_serialize,
     .deserialize = ws_protocol_decoder_lacrosse_tx_deserialize,
     .get_string = ws_protocol_decoder_lacrosse_tx_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder ws_protocol_lacrosse_tx_encoder = {

--- a/lib/subghz/protocols/lacrosse_tx141thbv2.c
+++ b/lib/subghz/protocols/lacrosse_tx141thbv2.c
@@ -62,6 +62,7 @@ const SubGhzProtocolDecoder ws_protocol_lacrosse_tx141thbv2_decoder = {
     .serialize = ws_protocol_decoder_lacrosse_tx141thbv2_serialize,
     .deserialize = ws_protocol_decoder_lacrosse_tx141thbv2_deserialize,
     .get_string = ws_protocol_decoder_lacrosse_tx141thbv2_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder ws_protocol_lacrosse_tx141thbv2_encoder = {

--- a/lib/subghz/protocols/linear.c
+++ b/lib/subghz/protocols/linear.c
@@ -54,6 +54,7 @@ const SubGhzProtocolDecoder subghz_protocol_linear_decoder = {
     .serialize = subghz_protocol_decoder_linear_serialize,
     .deserialize = subghz_protocol_decoder_linear_deserialize,
     .get_string = subghz_protocol_decoder_linear_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_linear_encoder = {

--- a/lib/subghz/protocols/linear_delta3.c
+++ b/lib/subghz/protocols/linear_delta3.c
@@ -55,6 +55,7 @@ const SubGhzProtocolDecoder subghz_protocol_linear_delta3_decoder = {
     .serialize = subghz_protocol_decoder_linear_delta3_serialize,
     .deserialize = subghz_protocol_decoder_linear_delta3_deserialize,
     .get_string = subghz_protocol_decoder_linear_delta3_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_linear_delta3_encoder = {

--- a/lib/subghz/protocols/magellan.c
+++ b/lib/subghz/protocols/magellan.c
@@ -50,6 +50,7 @@ const SubGhzProtocolDecoder subghz_protocol_magellan_decoder = {
     .serialize = subghz_protocol_decoder_magellan_serialize,
     .deserialize = subghz_protocol_decoder_magellan_deserialize,
     .get_string = subghz_protocol_decoder_magellan_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_magellan_encoder = {

--- a/lib/subghz/protocols/marantec.c
+++ b/lib/subghz/protocols/marantec.c
@@ -50,6 +50,7 @@ const SubGhzProtocolDecoder subghz_protocol_marantec_decoder = {
     .serialize = subghz_protocol_decoder_marantec_serialize,
     .deserialize = subghz_protocol_decoder_marantec_deserialize,
     .get_string = subghz_protocol_decoder_marantec_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_marantec_encoder = {

--- a/lib/subghz/protocols/mastercode.c
+++ b/lib/subghz/protocols/mastercode.c
@@ -62,6 +62,7 @@ const SubGhzProtocolDecoder subghz_protocol_mastercode_decoder = {
     .serialize = subghz_protocol_decoder_mastercode_serialize,
     .deserialize = subghz_protocol_decoder_mastercode_deserialize,
     .get_string = subghz_protocol_decoder_mastercode_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_mastercode_encoder = {

--- a/lib/subghz/protocols/megacode.c
+++ b/lib/subghz/protocols/megacode.c
@@ -60,6 +60,7 @@ const SubGhzProtocolDecoder subghz_protocol_megacode_decoder = {
     .serialize = subghz_protocol_decoder_megacode_serialize,
     .deserialize = subghz_protocol_decoder_megacode_deserialize,
     .get_string = subghz_protocol_decoder_megacode_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_megacode_encoder = {

--- a/lib/subghz/protocols/nero_radio.c
+++ b/lib/subghz/protocols/nero_radio.c
@@ -50,6 +50,7 @@ const SubGhzProtocolDecoder subghz_protocol_nero_radio_decoder = {
     .serialize = subghz_protocol_decoder_nero_radio_serialize,
     .deserialize = subghz_protocol_decoder_nero_radio_deserialize,
     .get_string = subghz_protocol_decoder_nero_radio_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_nero_radio_encoder = {

--- a/lib/subghz/protocols/nero_sketch.c
+++ b/lib/subghz/protocols/nero_sketch.c
@@ -49,6 +49,7 @@ const SubGhzProtocolDecoder subghz_protocol_nero_sketch_decoder = {
     .serialize = subghz_protocol_decoder_nero_sketch_serialize,
     .deserialize = subghz_protocol_decoder_nero_sketch_deserialize,
     .get_string = subghz_protocol_decoder_nero_sketch_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_nero_sketch_encoder = {

--- a/lib/subghz/protocols/nexus_th.c
+++ b/lib/subghz/protocols/nexus_th.c
@@ -345,6 +345,7 @@ const SubGhzProtocolDecoder ws_protocol_nexus_th_decoder = {
     .serialize = ws_protocol_decoder_nexus_th_serialize,
     .deserialize = ws_protocol_decoder_nexus_th_deserialize,
     .get_string = ws_protocol_decoder_nexus_th_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder ws_protocol_nexus_th_encoder = {

--- a/lib/subghz/protocols/nice_flo.c
+++ b/lib/subghz/protocols/nice_flo.c
@@ -47,6 +47,7 @@ const SubGhzProtocolDecoder subghz_protocol_nice_flo_decoder = {
     .serialize = subghz_protocol_decoder_nice_flo_serialize,
     .deserialize = subghz_protocol_decoder_nice_flo_deserialize,
     .get_string = subghz_protocol_decoder_nice_flo_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_nice_flo_encoder = {

--- a/lib/subghz/protocols/nice_flor_s.c
+++ b/lib/subghz/protocols/nice_flor_s.c
@@ -65,6 +65,7 @@ const SubGhzProtocolDecoder subghz_protocol_nice_flor_s_decoder = {
     .serialize = subghz_protocol_decoder_nice_flor_s_serialize,
     .deserialize = subghz_protocol_decoder_nice_flor_s_deserialize,
     .get_string = subghz_protocol_decoder_nice_flor_s_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_nice_flor_s_encoder = {

--- a/lib/subghz/protocols/oregon2.c
+++ b/lib/subghz/protocols/oregon2.c
@@ -419,6 +419,7 @@ const SubGhzProtocolDecoder ws_protocol_oregon2_decoder = {
     .serialize = ws_protocol_decoder_oregon2_serialize,
     .deserialize = ws_protocol_decoder_oregon2_deserialize,
     .get_string = ws_protocol_decoder_oregon2_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocol ws_protocol_oregon2 = {

--- a/lib/subghz/protocols/oregon3.c
+++ b/lib/subghz/protocols/oregon3.c
@@ -355,6 +355,7 @@ const SubGhzProtocolDecoder ws_protocol_oregon3_decoder = {
     .serialize = ws_protocol_decoder_oregon3_serialize,
     .deserialize = ws_protocol_decoder_oregon3_deserialize,
     .get_string = ws_protocol_decoder_oregon3_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocol ws_protocol_oregon3 = {

--- a/lib/subghz/protocols/oregon_v1.c
+++ b/lib/subghz/protocols/oregon_v1.c
@@ -81,6 +81,7 @@ const SubGhzProtocolDecoder ws_protocol_oregon_v1_decoder = {
     .serialize = ws_protocol_decoder_oregon_v1_serialize,
     .deserialize = ws_protocol_decoder_oregon_v1_deserialize,
     .get_string = ws_protocol_decoder_oregon_v1_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder ws_protocol_oregon_v1_encoder = {

--- a/lib/subghz/protocols/phoenix_v2.c
+++ b/lib/subghz/protocols/phoenix_v2.c
@@ -50,6 +50,7 @@ const SubGhzProtocolDecoder subghz_protocol_phoenix_v2_decoder = {
     .serialize = subghz_protocol_decoder_phoenix_v2_serialize,
     .deserialize = subghz_protocol_decoder_phoenix_v2_deserialize,
     .get_string = subghz_protocol_decoder_phoenix_v2_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_phoenix_v2_encoder = {

--- a/lib/subghz/protocols/pocsag.c
+++ b/lib/subghz/protocols/pocsag.c
@@ -425,6 +425,7 @@ const SubGhzProtocolDecoder subghz_protocol_pocsag_decoder = {
     .serialize = subghz_protocol_decoder_pocsag_serialize,
     .deserialize = subghz_protocol_decoder_pocsag_deserialize,
     .get_string = subhz_protocol_decoder_pocsag_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_pocsag_encoder = {

--- a/lib/subghz/protocols/power_smart.c
+++ b/lib/subghz/protocols/power_smart.c
@@ -57,6 +57,7 @@ const SubGhzProtocolDecoder subghz_protocol_power_smart_decoder = {
     .serialize = subghz_protocol_decoder_power_smart_serialize,
     .deserialize = subghz_protocol_decoder_power_smart_deserialize,
     .get_string = subghz_protocol_decoder_power_smart_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_power_smart_encoder = {

--- a/lib/subghz/protocols/princeton.c
+++ b/lib/subghz/protocols/princeton.c
@@ -58,6 +58,7 @@ const SubGhzProtocolDecoder subghz_protocol_princeton_decoder = {
     .serialize = subghz_protocol_decoder_princeton_serialize,
     .deserialize = subghz_protocol_decoder_princeton_deserialize,
     .get_string = subghz_protocol_decoder_princeton_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_princeton_encoder = {

--- a/lib/subghz/protocols/raw.c
+++ b/lib/subghz/protocols/raw.c
@@ -62,6 +62,7 @@ const SubGhzProtocolDecoder subghz_protocol_raw_decoder = {
     .serialize = NULL,
     .deserialize = subghz_protocol_decoder_raw_deserialize,
     .get_string = subghz_protocol_decoder_raw_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_raw_encoder = {

--- a/lib/subghz/protocols/scher_khan.c
+++ b/lib/subghz/protocols/scher_khan.c
@@ -56,6 +56,7 @@ const SubGhzProtocolDecoder subghz_protocol_scher_khan_decoder = {
     .serialize = subghz_protocol_decoder_scher_khan_serialize,
     .deserialize = subghz_protocol_decoder_scher_khan_deserialize,
     .get_string = subghz_protocol_decoder_scher_khan_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_scher_khan_encoder = {

--- a/lib/subghz/protocols/schrader_gg4.c
+++ b/lib/subghz/protocols/schrader_gg4.c
@@ -87,6 +87,7 @@ const SubGhzProtocolDecoder tpms_protocol_schrader_gg4_decoder = {
     .serialize = tpms_protocol_decoder_schrader_gg4_serialize,
     .deserialize = tpms_protocol_decoder_schrader_gg4_deserialize,
     .get_string = tpms_protocol_decoder_schrader_gg4_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder tpms_protocol_schrader_gg4_encoder = {

--- a/lib/subghz/protocols/secplus_v1.c
+++ b/lib/subghz/protocols/secplus_v1.c
@@ -71,6 +71,7 @@ const SubGhzProtocolDecoder subghz_protocol_secplus_v1_decoder = {
     .serialize = subghz_protocol_decoder_secplus_v1_serialize,
     .deserialize = subghz_protocol_decoder_secplus_v1_deserialize,
     .get_string = subghz_protocol_decoder_secplus_v1_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_secplus_v1_encoder = {

--- a/lib/subghz/protocols/secplus_v2.c
+++ b/lib/subghz/protocols/secplus_v2.c
@@ -65,6 +65,7 @@ const SubGhzProtocolDecoder subghz_protocol_secplus_v2_decoder = {
     .serialize = subghz_protocol_decoder_secplus_v2_serialize,
     .deserialize = subghz_protocol_decoder_secplus_v2_deserialize,
     .get_string = subghz_protocol_decoder_secplus_v2_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_secplus_v2_encoder = {

--- a/lib/subghz/protocols/smc5326.c
+++ b/lib/subghz/protocols/smc5326.c
@@ -73,6 +73,7 @@ const SubGhzProtocolDecoder subghz_protocol_smc5326_decoder = {
     .serialize = subghz_protocol_decoder_smc5326_serialize,
     .deserialize = subghz_protocol_decoder_smc5326_deserialize,
     .get_string = subghz_protocol_decoder_smc5326_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_smc5326_encoder = {

--- a/lib/subghz/protocols/somfy_keytis.c
+++ b/lib/subghz/protocols/somfy_keytis.c
@@ -54,6 +54,7 @@ const SubGhzProtocolDecoder subghz_protocol_somfy_keytis_decoder = {
     .serialize = subghz_protocol_decoder_somfy_keytis_serialize,
     .deserialize = subghz_protocol_decoder_somfy_keytis_deserialize,
     .get_string = subghz_protocol_decoder_somfy_keytis_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocol subghz_protocol_somfy_keytis = {

--- a/lib/subghz/protocols/somfy_telis.c
+++ b/lib/subghz/protocols/somfy_telis.c
@@ -55,6 +55,7 @@ const SubGhzProtocolDecoder subghz_protocol_somfy_telis_decoder = {
     .serialize = subghz_protocol_decoder_somfy_telis_serialize,
     .deserialize = subghz_protocol_decoder_somfy_telis_deserialize,
     .get_string = subghz_protocol_decoder_somfy_telis_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_somfy_telis_encoder = {

--- a/lib/subghz/protocols/star_line.c
+++ b/lib/subghz/protocols/star_line.c
@@ -65,6 +65,7 @@ const SubGhzProtocolDecoder subghz_protocol_star_line_decoder = {
     .serialize = subghz_protocol_decoder_star_line_serialize,
     .deserialize = subghz_protocol_decoder_star_line_deserialize,
     .get_string = subghz_protocol_decoder_star_line_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_star_line_encoder = {

--- a/lib/subghz/protocols/thermopro_tx4.c
+++ b/lib/subghz/protocols/thermopro_tx4.c
@@ -65,6 +65,7 @@ const SubGhzProtocolDecoder ws_protocol_thermopro_tx4_decoder = {
     .serialize = ws_protocol_decoder_thermopro_tx4_serialize,
     .deserialize = ws_protocol_decoder_thermopro_tx4_deserialize,
     .get_string = ws_protocol_decoder_thermopro_tx4_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder ws_protocol_thermopro_tx4_encoder = {

--- a/lib/subghz/protocols/tx_8300.c
+++ b/lib/subghz/protocols/tx_8300.c
@@ -76,6 +76,7 @@ const SubGhzProtocolDecoder ws_protocol_tx_8300_decoder = {
     .serialize = ws_protocol_decoder_tx_8300_serialize,
     .deserialize = ws_protocol_decoder_tx_8300_deserialize,
     .get_string = ws_protocol_decoder_tx_8300_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder ws_protocol_tx_8300_encoder = {

--- a/lib/subghz/protocols/wendox_w6726.c
+++ b/lib/subghz/protocols/wendox_w6726.c
@@ -70,6 +70,7 @@ const SubGhzProtocolDecoder ws_protocol_wendox_w6726_decoder = {
     .serialize = ws_protocol_decoder_wendox_w6726_serialize,
     .deserialize = ws_protocol_decoder_wendox_w6726_deserialize,
     .get_string = ws_protocol_decoder_wendox_w6726_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder ws_protocol_wendox_w6726_encoder = {

--- a/lib/subghz/protocols/x10.c
+++ b/lib/subghz/protocols/x10.c
@@ -76,6 +76,7 @@ const SubGhzProtocolDecoder subghz_protocol_x10_decoder = {
     .serialize = subghz_protocol_decoder_x10_serialize,
     .deserialize = subghz_protocol_decoder_x10_deserialize,
     .get_string = subghz_protocol_decoder_x10_get_string,
+    .get_string_brief = NULL,
 };
 
 const SubGhzProtocolEncoder subghz_protocol_x10_encoder = {

--- a/lib/subghz/types.h
+++ b/lib/subghz/types.h
@@ -81,6 +81,7 @@ typedef void (*SubGhzDecoderReset)(void* decoder);
 typedef uint8_t (*SubGhzGetHashData)(void* decoder);
 typedef uint32_t (*SubGhzGetHashDataLong)(void* decoder);
 typedef void (*SubGhzGetString)(void* decoder, FuriString* output);
+typedef void (*SubGhzGetStringBrief)(void* decoder, FuriString* output);
 
 // Encoder specific
 typedef void (*SubGhzEncoderStop)(void* encoder);
@@ -99,6 +100,7 @@ typedef struct {
     SubGhzDeserialize deserialize;
 
     SubGhzGetHashDataLong get_hash_data_long;
+    SubGhzGetStringBrief get_string_brief;
 } SubGhzProtocolDecoder;
 
 typedef struct {


### PR DESCRIPTION
# What's new

- SubGHz decoders can provide a one-line string to be used in the history list.
- Improve Hormann BiSecur readability in SubGHz history, so that the serial number and a hash of the encrypted bytes can be seen without exiting the list.
- Increase deduplication threshold in SubGHz history from 500 to 600 ms.

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable
