### PR TITLE
Infrared: Correct Samsung.ir CH+ command

### DIFF
--- a/applications/main/infrared/resources/infrared/Samsung.ir
+++ b/applications/main/infrared/resources/infrared/Samsung.ir
@@ -77,7 +77,7 @@ name: CH+
 type: parsed
 protocol: Samsung32
 address: 07 00 00 00
-command: 10 00 00 00
+command: 12 00 00 00
 # 
 name: CH-
 type: parsed


### PR DESCRIPTION
# What's new

- CH+ and CH- commands have same command currently
- CH+ is supposed to be 12 00 00 00 instead of 10 00 00 00
- Verified by comparing other files on UberGuidoZ repo and by checking own remotes

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable
