### PR TITLE
Sub-GHz: Nexus-TH weather station protocol improvements on detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
     - Enforce int module (like in OFW) usage due to lack of required hardware on external boards (PathIsolate (+rf switch for multiple paths)) and incorrect usage and/or understanding the purpose of frequency analyzer app by users, it should be used only to get frequency of the remote placed around 1-10cm around flipper's left corner
     - Fix possible GSM mobile towers signal interference by limiting upper frequency to 920mhz max
     - Fix duplicated frequency lists and use user config for nearest frequency selector too
+  - Nexus-TH weather station protocol improvements on detection (#256 by @m7i-org)
 - Infrared:
   - Additions to MNTM specific LED, Digital Sign, Monitor universal remotes from IRDB (#240 by @jaylikesbunda)
   - UL: Replace LEDs universal remote with new one by Unleashed team, includes color options (by @amec0e & @xMasterX)


### PR DESCRIPTION
# What's new

Added detection improvements for Nexus-TH as in https://github.com/merbanan/rtl_433/blob/00bd97c63a58083d2a79ccb7089786ff9d0fda2e/src/devices/nexus.c#L63-L78 :
 - If hum==0% there's no humidity sensor, so don't overwrite to 20%
 - If the Rubicson check matches, then it's probably not a Nexus-TH
 - Check temp range beween -50C and 100C

I haven't found the time of looking into changing the display name (rtl_433 calls the sensor a Nexus-T if there's no humidity), but I think this is good enough.

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable
