### PR TITLE
NFC: Goofy ISO15693 block sizes?

### DIFF
--- a/applications/main/nfc/helpers/protocol_support/iso15693_3/iso15693_3_render.c
+++ b/applications/main/nfc/helpers/protocol_support/iso15693_3/iso15693_3_render.c
@@ -90,7 +90,6 @@ void nfc_render_iso15693_3_extra(const Iso15693_3Data* data, FuriString* str) {
     }
 
     if(data->system_info.flags & ISO15693_3_SYSINFO_FLAG_AFI) {
-        furi_string_cat_printf(
-            str, "AFI: %s locked\n", data->settings.lock_bits.dsfid ? "" : "not");
+        furi_string_cat_printf(str, "AFI: %s locked\n", data->settings.lock_bits.afi ? "" : "not");
     }
 }

--- a/lib/nfc/protocols/iso15693_3/iso15693_3_i.c
+++ b/lib/nfc/protocols/iso15693_3/iso15693_3_i.c
@@ -131,9 +131,12 @@ Iso15693_3Error
         }
 
         if(data->flags & ISO15693_3_SYSINFO_FLAG_MEMORY) {
-            // Add 1 to get actual values
-            data->block_count = *extra++ + 1;
-            data->block_size = (*extra++ & 0x1F) + 1;
+            data->block_count = *extra++;
+            data->block_size = (*extra++ & 0x1F);
+            // Some tags report values -1 than actual values for some reason
+            // Some others don't, so let's just assume people use even numbers
+            if(data->block_count % 2) data->block_count++;
+            if(data->block_size % 2) data->block_size++;
         }
 
         if(data->flags & ISO15693_3_SYSINFO_FLAG_IC_REF) {

--- a/lib/nfc/protocols/iso15693_3/iso15693_3_listener_i.c
+++ b/lib/nfc/protocols/iso15693_3/iso15693_3_listener_i.c
@@ -536,8 +536,8 @@ static Iso15693_3Error iso15693_3_listener_get_system_info_handler(
         }
         if(system_flags & ISO15693_3_SYSINFO_FLAG_MEMORY) {
             const uint8_t memory_info[2] = {
-                instance->data->system_info.block_count - 1,
-                instance->data->system_info.block_size - 1,
+                instance->data->system_info.block_count,
+                instance->data->system_info.block_size,
             };
             bit_buffer_append_bytes(instance->tx_buffer, memory_info, COUNT_OF(memory_info));
         }


### PR DESCRIPTION
# What's new

- some tags seem to report block size/count values -1 than real values
- others dont, so they dont read correctly with existing code
- this is just for testing, its a shitty solution, just to see if this is the actual problem

-----
# For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ ] I've confirmed the bug to be fixed / feature to be stable
