### PR TITLE
RPC: Add ASCII event support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 - JS:
   - New `i2c` module (#259 by @jamisonderek)
   - New `spi` module (#272 by @jamisonderek)
+- RPC: Added ASCII event support (#284 by @Willy-JL)
 - BadKB:
   - OFW: Add linux/gnome badusb demo files (by @thomasnemer)
   - Add older qFlipper install demos for windows and macos (by @DXVVAY & @grugnoymeme)


### PR DESCRIPTION
# What's new

- RPC can send ASCII events to input pipeline

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable
