### PR TITLE
JS: Add illegalSymbols prop for gui/text_input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,10 +80,17 @@
   - Option to "Load from Library File" for Universal Remotes (#255 by @zxkmm)
 - Updater: New Yappy themed icon while updating (#253 by @the1anonlypr3 & @Kuronons & @nescap)
 - JS:
-  - New `i2c` module (#259 by @jamisonderek)
-  - New `spi` module (#272 by @jamisonderek)
+  - OFW: JS: Modules backport & overhaul (by @portasynthinca3)
+    - See above for list of breaking changes, here are listed strictly new functionalities
+    - New `event_loop` module for event-driven interactivity
+    - Interrupt and callback support for `gpio` module
+    - New `gui` module that allows much more developed interfaces, also new `gui/loading` and `gui/empty_screen` views
+    - Directory operations and many more file operations for `storage` module
   - OFW: Full-fledged JS SDK + npm packages (by @portasynthinca3)
     - CFWs can have their own JS SDKs too! Check ours out at [`@next-flip/fz-sdk-mntm`](https://www.npmjs.com/package/@next-flip/fz-sdk-mntm)
+  - New `i2c` module (#259 by @jamisonderek)
+  - New `spi` module (#272 by @jamisonderek)
+  - Added `illegalSymbols` prop for `gui/text_input` view (#290 by @Willy-JL)
   - Added typedocs for all extra JS modules in Momentum (by @Willy-JL)
 - RPC: Added ASCII event support (#284 by @Willy-JL)
 - OFW: Settings: Clock editing & Alarm function (目覚め時計) (by @skotopes)

--- a/applications/system/js_app/examples/apps/Scripts/Examples/gui.js
+++ b/applications/system/js_app/examples/apps/Scripts/Examples/gui.js
@@ -45,6 +45,12 @@ let views = {
     }),
 };
 
+// Enable illegal filename symbols since we're not choosing filenames, gives more flexibility
+// Not available in all firmwares, good idea to check if it is supported
+if (doesSdkSupport(["gui-textinput-illegalsymbols"])) {
+    views.textInput.set("illegalSymbols", true);
+}
+
 // demo selector
 eventLoop.subscribe(views.demos.chosen, function (_sub, index, gui, eventLoop, views) {
     if (index === 0) {

--- a/applications/system/js_app/examples/apps/Scripts/Examples/gui.js
+++ b/applications/system/js_app/examples/apps/Scripts/Examples/gui.js
@@ -48,7 +48,7 @@ let views = {
 // Enable illegal filename symbols since we're not choosing filenames, gives more flexibility
 // Not available in all firmwares, good idea to check if it is supported
 if (doesSdkSupport(["gui-textinput-illegalsymbols"])) {
-    views.textInput.set("illegalSymbols", true);
+    views.keyboard.set("illegalSymbols", true);
 }
 
 // demo selector

--- a/applications/system/js_app/examples/apps/Scripts/interactive.js
+++ b/applications/system/js_app/examples/apps/Scripts/interactive.js
@@ -32,6 +32,12 @@ let views = {
     loading: loading.make(),
 };
 
+// Enable illegal filename symbols since we're not choosing filenames, gives more flexibility
+// Not available in all firmwares, good idea to check if it is supported
+if (doesSdkSupport(["gui-textinput-illegalsymbols"])) {
+    views.textInput.set("illegalSymbols", true);
+}
+
 eventLoop.subscribe(views.dialog.input, function (_sub, button, gui, views) {
     if (button === "center") {
         gui.viewDispatcher.switchTo(views.textInput);

--- a/applications/system/js_app/js_modules.c
+++ b/applications/system/js_app/js_modules.c
@@ -278,6 +278,7 @@ static const char* extra_features[] = {
     "widget",
 
     // extra features
+    "gui-textinput-illegalsymbols",
     "storage-virtual",
     "usbdisk-createimage",
     "widget-addicon",

--- a/applications/system/js_app/modules/js_gui/text_input.c
+++ b/applications/system/js_app/modules/js_gui/text_input.c
@@ -115,6 +115,18 @@ static bool default_text_clear_assign(
     return true;
 }
 
+static bool illegal_symbols_assign(
+    struct mjs* mjs,
+    TextInput* input,
+    JsViewPropValue value,
+    JsKbdContext* context) {
+    UNUSED(mjs);
+    UNUSED(context);
+
+    text_input_show_illegal_symbols(input, value.boolean);
+    return true;
+}
+
 static JsKbdContext* ctx_make(struct mjs* mjs, TextInput* input, mjs_val_t view_obj) {
     JsKbdContext* context = malloc(sizeof(JsKbdContext));
     *context = (JsKbdContext){
@@ -135,7 +147,6 @@ static JsKbdContext* ctx_make(struct mjs* mjs, TextInput* input, mjs_val_t view_
                 .transformer_context = context,
             },
     };
-    text_input_show_illegal_symbols(input, true); // Temporary until prop is available
     text_input_set_result_callback(
         input,
         (TextInputCallback)input_callback,
@@ -162,7 +173,7 @@ static const JsViewDescriptor view_descriptor = {
     .get_view = (JsViewGetView)text_input_get_view,
     .custom_make = (JsViewCustomMake)ctx_make,
     .custom_destroy = (JsViewCustomDestroy)ctx_destroy,
-    .prop_cnt = 5,
+    .prop_cnt = 6,
     .props = {
         (JsViewPropDescriptor){
             .name = "header",
@@ -184,6 +195,10 @@ static const JsViewDescriptor view_descriptor = {
             .name = "defaultTextClear",
             .type = JsViewPropTypeBool,
             .assign = (JsViewPropAssign)default_text_clear_assign},
+        (JsViewPropDescriptor){
+            .name = "illegalSymbols",
+            .type = JsViewPropTypeBool,
+            .assign = (JsViewPropAssign)illegal_symbols_assign},
     }};
 
 JS_GUI_VIEW_DEF(text_input, &view_descriptor);

--- a/applications/system/js_app/packages/fz-sdk/gui/text_input.d.ts
+++ b/applications/system/js_app/packages/fz-sdk/gui/text_input.d.ts
@@ -22,6 +22,7 @@
  *   - `maxLength`: Maximum allowed text length
  *   - `defaultText`: Text to show by default
  *   - `defaultTextClear`: Whether to clear the default text on next character typed
+ *   - `illegalSymbols`: Whether to show illegal filename symbols, available with JS feature `gui-textinput-illegalsymbols`
  * 
  * @version Added in JS SDK 0.1
  * @module
@@ -36,6 +37,7 @@ type Props = {
     maxLength: number,
     defaultText: string,
     defaultTextClear: boolean,
+    illegalSymbols: boolean,
 }
 declare class TextInput extends View<Props> {
     input: Contract<string>;

--- a/applications/system/js_app/packages/fz-sdk/package.json
+++ b/applications/system/js_app/packages/fz-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@next-flip/fz-sdk-mntm",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Type declarations and documentation for native JS modules available on Momentum Custom Firmware for Flipper Zero",
   "keywords": [
     "momentum",


### PR DESCRIPTION
# What's new

- [Describe changes here]

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable
