### PR TITLE
Asset Packer: Fix font terminator causing freezes/crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,7 @@
   - OFW: Fix detection of GProx II cards and false detection of other cards (by @Astrrra)
   - OFW: Fix Guard GProxII False Positive and 36-bit Parsing (by @zinongli)
   - OFW: GProxII Fix Writing and Rendering Conflict (by @zinongli)
+- Asset Packer: Fix font terminator causing freezes/crashes, like in Marauder AP scan/list (#295 by @Willy-JL)
 - Desktop:
   - Fallback Poweroff prompt when power settings is unavailable (by @Willy-JL)
 - Sub-GHz:

--- a/scripts/asset_packer.py
+++ b/scripts/asset_packer.py
@@ -119,6 +119,7 @@ def pack_font(src: pathlib.Path, dst: pathlib.Path):
                     .decode("unicode_escape")
                     .encode("latin_1")
                 )
+        font += b"\0"
         dst.with_suffix(".u8f").write_bytes(font)
     elif src.suffix == ".u8f":
         if not dst.is_file():


### PR DESCRIPTION
# What's new

- u8g2 fonts are compiled as C strings. this means they automatically get appended a 0x00 byte at the end. the string itself also ends with a \0 so u8g2 fonts end with 0x0000
- asset packer did not add the terminator, it only used the data present in the string itself, so only 1 0x00 byte was at the end
- this meant in some cases, when a glyph not present in the font was attempted to be drawn, u8g2 would reach the end of the font data, and overrun the buffer. depending on the byte that was immediately after the loaded font in ram, this could either have no repercussions, or it could freeze, or even crash
- asset packer now respects C string terminators, and the produced xu8f artifact is the same memory content as the u8g2 font would have when compiled into flash

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable
