### PR TITLE
Settings: Add warnings for settings you shouldn't touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,9 @@
   - Added typedocs for all extra JS modules in Momentum (by @Willy-JL)
 - RPC: Added ASCII event support (#284 by @Willy-JL)
 - FBT/SDK: New app flag UnloadAssetPacks to free RAM in heavy apps like NFC, MFKey, uPython (#260 by @Willy-JL)
-- OFW: Settings: Clock editing & Alarm function (目覚め時計) (by @skotopes)
+- Settings:
+  - OFW: Clock editing & Alarm function (目覚め時計) (by @skotopes)
+  - Add warnings for some settings you shouldn't touch like Debug, Sleep Method, Heap Trace (#296 by @Willy-JL)
 - BadKB:
   - OFW: Add linux/gnome badusb demo files (by @thomasnemer)
   - Add older qFlipper install demos for windows and macos (by @DXVVAY & @grugnoymeme)
@@ -179,7 +181,9 @@
   - Move more commands as plugins on SD, refactor plugin wrapper (#276 by @Willy-JL)
 - FBT: Optimize icons blob, scrub unused icons (#291 by @Willy-JL)
 - OFW: BadKB: Improve ChromeOS and GNOME demo scripts (by @kowalski7cc)
-- OFW: GUI: Change dialog_ex text ownership model (by @skotopes)
+- GUI:
+  - OFW: Change dialog_ex text ownership model (by @skotopes)
+  - Improve some error messages to be more clear, like Sub-GHz region missing and Main Menu .fap file missing (#296 by @Willy-JL)
 - OFW: CCID: App changes and improvements (by @kidbomb)
 - OFW: API: Exposed `view_dispatcher_get_event_loop` (by @CookiePLMonster)
 - Furi:

--- a/applications/main/subghz/subghz_i.c
+++ b/applications/main/subghz/subghz_i.c
@@ -51,7 +51,7 @@ void subghz_dialog_message_freq_error(SubGhz* subghz, SubGhzTx can_tx) {
     default:
         return;
     case SubGhzTxBlockedRegionNotProvisioned:
-        message_text = "Region is not\nprovisioned.\nUpdate firmware\nor bypass region.";
+        message_text = "Missing region file.\nReinstall firmware\nwith Web/App\nor bypass region.";
         break;
     case SubGhzTxBlockedRegion:
         message_text = "Frequency outside\nof region range.\nMNTM > Protocols\n> Bypass Region";

--- a/applications/services/cli/cli.c
+++ b/applications/services/cli/cli.c
@@ -596,7 +596,7 @@ void cli_plugin_wrapper(const char* name, Cli* cli, FuriString* args, void* cont
         handler(cli, args, context);
     } else {
         printf(
-            "CLI plugin '%s' failed (code %" PRIu16 "), update firmware or check logs\r\n",
+            "CLI plugin '%s' failed (code %" PRIu16 "), reinstall firmware or check logs\r\n",
             name,
             error);
     }

--- a/applications/services/loader/loader.c
+++ b/applications/services/loader/loader.c
@@ -107,7 +107,7 @@ static void loader_show_gui_error(
         Storage* storage = furi_record_open(RECORD_STORAGE);
         if(storage_sd_status(storage) == FSE_OK) {
             header = "Update needed";
-            text = "Update firmware\nto run this app";
+            text = "Reinstall firmware\nto run this app";
         } else {
             header = "SD card needed";
             text = "Install SD card\nto run this app";

--- a/applications/services/loader/loader_menu_storage.c
+++ b/applications/services/loader/loader_menu_storage.c
@@ -46,10 +46,10 @@ int32_t loader_menu_storage_settings(void* context) {
         dialog_ex_set_header(dialog_ex, "Update needed", 64, 0, AlignCenter, AlignTop);
         dialog_ex_set_text(
             dialog_ex,
-            "Update firmware\n"
-            "to run this app\n"
+            "Reinstall firmware\n"
+            "to run this app.\n"
             "Can format SD\n"
-            "here if needed",
+            "here if needed.",
             3,
             17,
             AlignLeft,


### PR DESCRIPTION
# What's new

- warnings for some settings: debug, heap trace, sleep mode
- hopefully will stop people enabling debug for no reason and crying that battery drains too fast

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable
