### PR TITLE
Main Menu: Fixes scrollable text in CoverFlow

### DIFF
--- a/applications/services/gui/modules/menu.c
+++ b/applications/services/gui/modules/menu.c
@@ -548,13 +548,14 @@ static void menu_draw_callback(Canvas* canvas, void* _model) {
             // Draw label for center item
             if(center_item) {
                 menu_get_name(center_item, name, false);
+                size_t scroll_counter = menu_scroll_counter(model, true);
                 elements_scrollable_text_line_centered(
                     canvas,
                     pos_x_center,
                     (pos_y_center + icon_size / 2) + pos_y_offset,
-                    126,
+                    124,
                     name,
-                    0,
+                    scroll_counter,
                     false,
                     true);
             }


### PR DESCRIPTION
In #314 

- `elements_scrollable_text_line_centered` was using 0 on scroll, so text wider than the screen would not scroll. Uses `menu_scroll_counter` to fix it.
- Also makes the width 124 to give a 1px margin so the text isn't touching the outside lines

https://github.com/user-attachments/assets/41af2f3e-8c7c-4915-a1cb-ad5f49da5073

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable
