### PR TITLE
Archive: Add item count to directory info scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - OFW: BadKB: Mouse control (by @jetrp1)
 - OFW: Infrared: Universal IR signal selection (by @portasynthinca3)
 - OFW: NFC: Disney Infinity KDF plugin (by @bettse)
+- Archive: Add item count to directory info scene (#378 by @956MB)
 - UL: Input: Vibro on Button press option (by @Dmitry422)
 - Desktop:
   - UL: Option to prevent Auto Lock when connected to USB/RPC (by @Dmitry422)

--- a/applications/main/archive/archive_i.h
+++ b/applications/main/archive/archive_i.h
@@ -43,7 +43,8 @@ struct ArchiveApp {
     char text_store[MAX_NAME_LEN];
     FuriString* file_extension;
 
-    WidgetElement* element;
+    WidgetElement* size_element;
+    WidgetElement* count_element;
     FuriThread* thread;
 };
 


### PR DESCRIPTION
Tiny personal addition to the Archive showing folders inner item count alongside the size. Very easy thing to merge into the dirwalk.

#### Before

![Without](https://github.com/user-attachments/assets/8f0f62dc-24d4-4e58-a7ff-56b03e6bdc18)

#### After

![With](https://github.com/user-attachments/assets/fb1481a6-884b-4ee4-84e6-3fddbd621e40)

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable
