### PR TITLE
BadKB: Add Linux KDE demo and qFlipper installation scripts

### DIFF
--- a/applications/main/bad_usb/resources/badusb/Demos/Install_qFlipper_KDE.txt
+++ b/applications/main/bad_usb/resources/badusb/Demos/Install_qFlipper_KDE.txt
@@ -1,0 +1,53 @@
+ID 1234:abcd Generic:USB Keyboard
+REM Identify as a generic USB keyboard
+
+REM This script installs qFlipper on Linux/KDE using the latest AppImage package
+
+REM Open the KDE terminal (Konsole)
+ALT F2
+DELAY 1000
+STRINGLN konsole --new-tab -e "bash -c 'clear; exec bash'"
+DELAY 1000
+
+REM Ensure the folder for executables exists
+STRINGLN mkdir -p $HOME/.local/bin
+
+REM Download the latest AppImage
+STRINGLN curl -fsSL "https://update.flipperzero.one/qFlipper/release/linux-amd64/AppImage" -o "$HOME/.local/bin/qFlipper"
+DELAY 1000
+
+REM Make it executable
+STRINGLN chmod +x $HOME/.local/bin/qFlipper
+
+REM Extract the AppImage in /tmp to install the icon and .desktop file
+STRINGLN cd /tmp
+STRINGLN $HOME/.local/bin/qFlipper --appimage-extract > /dev/null
+STRINGLN sed "s@Exec=qFlipper@Exec=$HOME/.local/bin/qFlipper@" squashfs-root/usr/share/applications/qFlipper.desktop > $HOME/.local/share/applications/qFlipper.desktop
+
+REM Create the icons folder if it does not exist
+STRINGLN mkdir -p $HOME/.local/share/icons/hicolor/512x512/apps
+STRINGLN cp squashfs-root/usr/share/icons/hicolor/512x512/apps/qFlipper.png $HOME/.local/share/icons/hicolor/512x512/apps/qFlipper.png
+
+REM Clean up the extracted folder
+STRINGLN rm -rf squashfs-root
+STRINGLN cd
+
+REM Update the desktop entries (for KDE, you might need to restart plasmashell)
+STRINGLN update-desktop-database $HOME/.local/share/applications || true
+
+REM Display final message to the user
+STRINGLN echo "
+ENTER
+REPEAT 60
+STRINGLN ==========================================================================================
+STRINGLN qFlipper has been installed to $HOME/.local/bin/
+STRINGLN It should appear in your Applications menu.
+STRINGLN If it does not, you might want to log out and log in again.
+ENTER
+STRINGLN To run qFlipper from your terminal, use the absolute path
+STRINGLN or ensure $HOME/.local/bin/ is included in your PATH environment variable.
+ENTER
+STRINGLN You might need additional configurations depending on your Linux distribution (such as
+STRINGLN group membership, udev rules, etc.).
+STRINGLN ==========================================================================================
+STRINGLN "

--- a/applications/main/bad_usb/resources/badusb/Demos/demo_kde.txt
+++ b/applications/main/bad_usb/resources/badusb/Demos/demo_kde.txt
@@ -1,0 +1,95 @@
+ID 1234:abcd Generic:USB Keyboard
+REM Declare ourselves as a generic usb keyboard
+REM You can override this to use something else
+REM Check the `lsusb` command to know your own devices IDs
+
+REM This is BadUSB demo script for Linux/KDE
+
+REM Exit from Overview
+ESC
+DELAY 200
+REM Open terminal window
+ALT F2
+DELAY 1000
+REM Open Konsole (KDE's terminal)
+STRING sh -c "konsole"
+DELAY 300
+ENTER
+REM Waiting for Konsole
+DELAY 1500
+
+REM Make sure we are running in a POSIX-compliant shell
+STRING env sh
+ENTER
+
+REM Clear the screen in case some banner was displayed
+STRING clear
+ENTER
+
+REM Bigger shell script example
+STRING cat > /dev/null << EOF
+ENTER
+
+STRING Hello World!
+ENTER
+
+DEFAULT_DELAY 50
+
+STRING =
+REPEAT 59
+ENTER
+ENTER
+
+STRING               _.-------.._                    -,
+ENTER
+HOME
+STRING           .-"'''"--..,,_/ /'-,               -,  \
+ENTER
+HOME
+STRING        .:"          /:/  /'\  \     ,_...,  '. |  |
+ENTER
+HOME
+STRING       /       ,----/:/  /'\ _\~'_-"'     _;
+ENTER
+HOME
+STRING      '      / /'"""'\ \ \.~'_-'      ,-"'/
+ENTER
+HOME
+STRING     |      | |  0    | | .-'      ,/'  /
+ENTER
+HOME
+STRING    |    ,..\ \     ,.-"'       ,/'    /
+ENTER
+HOME
+STRING   ;    :    '/'""\'           ,/--==,/-----,
+ENTER
+HOME
+STRING   |    '-...|        -.___-Z:_______J...---;
+ENTER
+HOME
+STRING   :         '                           _-'
+ENTER
+HOME
+STRING  _L_  _     ___  ___  ___  ___  ____--"'
+ENTER
+HOME
+STRING | __|| |   |_ _|| _ \| _ \| __|| _ \
+ENTER
+HOME
+STRING | _| | |__  | | |  _/|  _/| _| |   /
+ENTER
+HOME
+STRING |_|  |____||___||_|  |_|  |___||_|_\
+ENTER
+HOME
+ENTER
+
+STRING Flipper Zero BadUSB feature is compatible with USB Rubber Ducky script format
+ENTER
+STRING More information about script syntax can be found here:
+ENTER
+STRING https://github.com/flipperdevices/flipperzero-firmware/blob/dev/documentation/file_formats/BadUsbScriptFormat.md
+ENTER
+
+STRING EOF
+ENTER


### PR DESCRIPTION
# What's new

- Add KDE demo with Konsole
- Add KDE qFlipper installation

-----
# For the reviewer

- [x] This change was tested on my Arch Linux KDE setup
- [x] I've confirmed this is working
