### PR TITLE
Asset Packs: Fixes custom font position in speech bubbles

### DIFF
--- a/applications/services/desktop/animations/views/bubble_animation_view.c
+++ b/applications/services/desktop/animations/views/bubble_animation_view.c
@@ -84,7 +84,11 @@ static void bubble_animation_draw_callback(Canvas* canvas, void* model_) {
         if((model->current_frame >= bubble->start_frame) &&
            (model->current_frame <= bubble->end_frame)) {
             const Bubble* b = &bubble->bubble;
-            elements_bubble_str(canvas, b->x, b->y, b->text, b->align_h, b->align_v);
+            const CanvasFontParameters* font_params =
+                canvas_get_font_params(canvas, FontSecondary);
+            int32_t y_offset =
+                font_params != &canvas_font_params[FontSecondary] ? (font_params->height / 2) : 0;
+            elements_bubble_str(canvas, b->x, b->y, y_offset, b->text, b->align_h, b->align_v);
         }
     }
 }

--- a/applications/services/desktop/views/desktop_view_locked.c
+++ b/applications/services/desktop/views/desktop_view_locked.c
@@ -117,13 +117,24 @@ void desktop_view_locked_draw_lockscreen(Canvas* canvas, void* m) {
     if(model->view_state == DesktopViewLockedStateLockedHintShown &&
        momentum_settings.lockscreen_prompt) {
         canvas_set_font(canvas, FontSecondary);
+
+        const CanvasFontParameters* font_params = canvas_get_font_params(canvas, FontSecondary);
+        int32_t y_offset =
+            font_params != &canvas_font_params[FontSecondary] ? (font_params->height / 2) : 0;
+
         if(model->pin_locked) {
             elements_bubble_str(
-                canvas, 12, 14 + y, "  Press   \nto unlock!", AlignRight, AlignBottom);
+                canvas, 12, 14 + y, y_offset, "  Press   \nto unlock!", AlignRight, AlignBottom);
             canvas_draw_icon(canvas, 45, 16 + y, &I_Pin_arrow_up_7x9);
         } else {
             elements_bubble_str(
-                canvas, 2, 14 + y, "Press 3x      \n  to unlock!", AlignRight, AlignBottom);
+                canvas,
+                2,
+                14 + y,
+                y_offset,
+                "Press 3x      \n  to unlock!",
+                AlignRight,
+                AlignBottom);
             canvas_draw_icon(canvas, 43, 17 + y, &I_Pin_back_arrow_10x8);
         }
     }

--- a/applications/services/gui/canvas.h
+++ b/applications/services/gui/canvas.h
@@ -82,6 +82,8 @@ typedef enum {
     IconRotation270,
 } IconRotation;
 
+extern const CanvasFontParameters canvas_font_params[FontTotalNumber];
+
 /** Canvas anonymous structure */
 typedef struct Canvas Canvas;
 

--- a/applications/services/gui/elements.c
+++ b/applications/services/gui/elements.c
@@ -528,6 +528,7 @@ void elements_bubble_str(
     Canvas* canvas,
     int32_t x,
     int32_t y,
+    int32_t y_offset,
     const char* text,
     Align horizontal,
     Align vertical) {
@@ -558,7 +559,7 @@ void elements_bubble_str(
     canvas_draw_box(canvas, frame_x + 1, frame_y + 1, frame_width - 2, frame_height - 2);
     canvas_set_color(canvas, ColorBlack);
     canvas_draw_rframe(canvas, frame_x, frame_y, frame_width, frame_height, 1);
-    elements_multiline_text(canvas, x + 4, y - 1 + font_height, text);
+    elements_multiline_text(canvas, x + 4, y - 1 + font_height + y_offset, text);
 
     int32_t x1 = 0;
     int32_t x2 = 0;

--- a/applications/services/gui/elements.h
+++ b/applications/services/gui/elements.h
@@ -230,6 +230,7 @@ void elements_bubble(Canvas* canvas, int32_t x, int32_t y, size_t width, size_t 
  * @param   canvas      Canvas instance
  * @param   x           left x coordinates
  * @param   y           top y coordinate
+ * @param   y_offset    y offset used for custom font ascent
  * @param   text        text to display
  * @param   horizontal  horizontal aligning
  * @param   vertical    aligning
@@ -238,6 +239,7 @@ void elements_bubble_str(
     Canvas* canvas,
     int32_t x,
     int32_t y,
+    int32_t y_offset,
     const char* text,
     Align horizontal,
     Align vertical);

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1001,7 +1001,7 @@ Function,-,drem,double,"double, double"
 Function,-,dremf,float,"float, float"
 Function,+,elements_bold_rounded_frame,void,"Canvas*, int32_t, int32_t, size_t, size_t"
 Function,+,elements_bubble,void,"Canvas*, int32_t, int32_t, size_t, size_t"
-Function,+,elements_bubble_str,void,"Canvas*, int32_t, int32_t, const char*, Align, Align"
+Function,+,elements_bubble_str,void,"Canvas*, int32_t, int32_t, int32_t, const char*, Align, Align"
 Function,+,elements_button_center,void,"Canvas*, const char*"
 Function,+,elements_button_down,void,"Canvas*, const char*"
 Function,+,elements_button_left,void,"Canvas*, const char*"
@@ -4234,6 +4234,7 @@ Variable,-,_sys_errlist,const char* const[],
 Variable,-,_sys_nerr,int,
 Variable,-,ble_profile_hid,const FuriHalBleProfileTemplate*,
 Variable,+,ble_profile_serial,const FuriHalBleProfileTemplate* const,
+Variable,+,canvas_font_params,const CanvasFontParameters[FontTotalNumber],
 Variable,+,cli_vcp,const CliSession,
 Variable,+,compress_config_heatshrink_default,const CompressConfigHeatshrink,
 Variable,+,firmware_api_interface,const ElfApiInterface* const,


### PR DESCRIPTION
Fixes the misaligned custom fonts in bubbles by checking if the current secondary font is a custom font loaded by your asset pack, then adds a small offset to properly center it.

| Before | After |
|--------|-------|
| ![FontAscentLockscreenBefore](https://github.com/user-attachments/assets/fde6a69f-b8f2-4762-8e84-c964e55e10b0) | ![FontAscentLockscreenAfter](https://github.com/user-attachments/assets/03c301c9-290f-48a1-ab8c-41f126576f7a) |
| ![FontAscentDesktopBefore](https://github.com/user-attachments/assets/76bbeebc-6c79-4485-8e94-068d29beef40) | ![FontAscentDesktopAfter](https://github.com/user-attachments/assets/692a1400-9dde-457d-be42-276c410e9eaf) |

-----
# For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ ] I've confirmed the bug to be fixed / feature to be stable
