### PR TITLE
RFID: Add DEZ10 representation to EM410X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - WiFi Marauder: Support for new commands from ESP32Marauder 1.6.x (by @justcallmekoko)
   - VGM Tool: Fixed RGB firmware UART regression (by @WillyJL)
   - UL: Sub-GHz Playlist: Add support for custom modulation presets, remake with txrx library and support for dynamic signals, cleanup code (by @xMasterX)
+- RFID: Add DEZ10 representation to EM410X (by @realcatgirly)
 - OFW: Infrared: Add text scroll to remote buttons (by @956MB)
 - Sub-GHz:
   - UL: Rename and extend Alarms ignore option with Hollarm & GangQi (by @xMasterX)

--- a/applications/main/lfrfid/scenes/lfrfid_scene_read_success.c
+++ b/applications/main/lfrfid/scenes/lfrfid_scene_read_success.c
@@ -41,8 +41,7 @@ void lfrfid_scene_read_success_on_enter(void* context) {
     furi_string_cat_printf(display_text, "\n%s", furi_string_get_cstr(rendered_data));
     furi_string_free(rendered_data);
 
-    widget_add_text_scroll_element(
-        widget, 0, 16, 128, 32, furi_string_get_cstr(display_text));
+    widget_add_text_scroll_element(widget, 0, 16, 128, 32, furi_string_get_cstr(display_text));
     widget_add_button_element(widget, GuiButtonTypeLeft, "Retry", lfrfid_widget_callback, app);
     widget_add_button_element(widget, GuiButtonTypeRight, "More", lfrfid_widget_callback, app);
 

--- a/applications/main/lfrfid/scenes/lfrfid_scene_read_success.c
+++ b/applications/main/lfrfid/scenes/lfrfid_scene_read_success.c
@@ -41,8 +41,8 @@ void lfrfid_scene_read_success_on_enter(void* context) {
     furi_string_cat_printf(display_text, "\n%s", furi_string_get_cstr(rendered_data));
     furi_string_free(rendered_data);
 
-    widget_add_text_box_element(
-        widget, 0, 16, 128, 52, AlignLeft, AlignTop, furi_string_get_cstr(display_text), true);
+    widget_add_text_scroll_element(
+        widget, 0, 16, 128, 32, furi_string_get_cstr(display_text));
     widget_add_button_element(widget, GuiButtonTypeLeft, "Retry", lfrfid_widget_callback, app);
     widget_add_button_element(widget, GuiButtonTypeRight, "More", lfrfid_widget_callback, app);
 

--- a/applications/main/lfrfid/scenes/lfrfid_scene_read_success.c
+++ b/applications/main/lfrfid/scenes/lfrfid_scene_read_success.c
@@ -41,7 +41,7 @@ void lfrfid_scene_read_success_on_enter(void* context) {
     furi_string_cat_printf(display_text, "\n%s", furi_string_get_cstr(rendered_data));
     furi_string_free(rendered_data);
 
-    widget_add_text_scroll_element(widget, 0, 16, 128, 32, furi_string_get_cstr(display_text));
+    widget_add_text_scroll_element(widget, 0, 16, 128, 35, furi_string_get_cstr(display_text));
     widget_add_button_element(widget, GuiButtonTypeLeft, "Retry", lfrfid_widget_callback, app);
     widget_add_button_element(widget, GuiButtonTypeRight, "More", lfrfid_widget_callback, app);
 

--- a/lib/lfrfid/protocols/protocol_em4100.c
+++ b/lib/lfrfid/protocols/protocol_em4100.c
@@ -374,11 +374,13 @@ void protocol_em4100_render_data(ProtocolEM4100* protocol, FuriString* result) {
     furi_string_printf(
         result,
         "FC: %03u Card: %05hu CL:%hhu\n"
-        "DEZ 8: %08lu",
+        "DEZ 8: %08lu\n"
+        "DEZ 10: %010llu",
         data[2],
         (uint16_t)((data[3] << 8) | (data[4])),
         protocol->clock_per_bit,
-        (uint32_t)((data[2] << 16) | (data[3] << 8) | (data[4])));
+        (uint32_t)((data[2] << 16) | (data[3] << 8) | (data[4])),
+        (uint64_t)((data[1] << 24) | (data[2] << 16) | (data[3] << 8) | (data[4])));
 }
 
 const ProtocolBase protocol_em4100 = {

--- a/lib/lfrfid/protocols/protocol_em4100.c
+++ b/lib/lfrfid/protocols/protocol_em4100.c
@@ -375,12 +375,12 @@ void protocol_em4100_render_data(ProtocolEM4100* protocol, FuriString* result) {
         result,
         "FC: %03u Card: %05hu CL:%hhu\n"
         "DEZ 8: %08lu\n"
-        "DEZ 10: %010llu",
+        "DEZ 10: %010lu",
         data[2],
         (uint16_t)((data[3] << 8) | (data[4])),
         protocol->clock_per_bit,
         (uint32_t)((data[2] << 16) | (data[3] << 8) | (data[4])),
-        (uint64_t)((data[1] << 24) | (data[2] << 16) | (data[3] << 8) | (data[4])));
+        (uint32_t)((data[1] << 24) | (data[2] << 16) | (data[3] << 8) | (data[4])));
 }
 
 const ProtocolBase protocol_em4100 = {


### PR DESCRIPTION
# What's new

- Adds DEZ10 decoding for EM410X RFID cards
- Makes the EM410X read-success scene scrollable to account for the additional content
- addresses #224

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the feature to be stable
