### PR TITLE
MNTM Settings: Add Skip Sliding Animations option for Lockscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - UL: Nero Radio static parse and display more data (by @xMasterX)
   - UL: Marantec protocol implement CRC verification display and add manually support (by @xMasterX & @li0ard, original code by @Skorpionm)
   - UL: Keeloq Comunello add manually support (by @xMasterX)
+- MNTM Settings: Add Skip Sliding Animations option to skip cover animations (by @aaronjamt)
 
 ### Updated:
 - Apps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   - UL: Nero Radio static parse and display more data (by @xMasterX)
   - UL: Marantec protocol implement CRC verification display and add manually support (by @xMasterX & @li0ard, original code by @Skorpionm)
   - UL: Keeloq Comunello add manually support (by @xMasterX)
-- MNTM Settings: Add Skip Sliding Animations option to skip cover animations (by @aaronjamt)
+- MNTM Settings: Add Skip Sliding Animations option for Lockscreen (by @aaronjamt)
 
 ### Updated:
 - Apps:

--- a/applications/main/momentum_app/scenes/momentum_app_scene_interface_lockscreen.c
+++ b/applications/main/momentum_app/scenes/momentum_app_scene_interface_lockscreen.c
@@ -110,6 +110,24 @@ static void
     app->save_settings = true;
 }
 
+static void
+    momentum_app_scene_interface_lockscreen_lockscreen_fast_unlock_changed(VariableItem* item) {
+    MomentumApp* app = variable_item_get_context(item);
+    bool value = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, value ? "ON" : "OFF");
+    momentum_settings.lockscreen_fast_unlock = value;
+    app->save_settings = true;
+}
+
+static void
+    momentum_app_scene_interface_lockscreen_lockscreen_fast_lock_changed(VariableItem* item) {
+    MomentumApp* app = variable_item_get_context(item);
+    bool value = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, value ? "ON" : "OFF");
+    momentum_settings.lockscreen_fast_lock = value;
+    app->save_settings = true;
+}
+
 void momentum_app_scene_interface_lockscreen_on_enter(void* context) {
     MomentumApp* app = context;
     VariableItemList* var_item_list = app->var_item_list;
@@ -219,6 +237,26 @@ void momentum_app_scene_interface_lockscreen_on_enter(void* context) {
     variable_item_set_current_value_index(item, momentum_settings.lockscreen_transparent);
     variable_item_set_current_value_text(
         item, momentum_settings.lockscreen_transparent ? "ON" : "OFF");
+
+    item = variable_item_list_add(
+        var_item_list,
+        "Fast Unlock",
+        2,
+        momentum_app_scene_interface_lockscreen_lockscreen_fast_unlock_changed,
+        app);
+    variable_item_set_current_value_index(item, momentum_settings.lockscreen_fast_unlock);
+    variable_item_set_current_value_text(
+        item, momentum_settings.lockscreen_fast_unlock ? "ON" : "OFF");
+
+    item = variable_item_list_add(
+        var_item_list,
+        "Fast Lock",
+        2,
+        momentum_app_scene_interface_lockscreen_lockscreen_fast_lock_changed,
+        app);
+    variable_item_set_current_value_index(item, momentum_settings.lockscreen_fast_lock);
+    variable_item_set_current_value_text(
+        item, momentum_settings.lockscreen_fast_lock ? "ON" : "OFF");
 
     variable_item_list_set_enter_callback(
         var_item_list, momentum_app_scene_interface_lockscreen_var_item_list_callback, app);

--- a/applications/main/momentum_app/scenes/momentum_app_scene_interface_lockscreen.c
+++ b/applications/main/momentum_app/scenes/momentum_app_scene_interface_lockscreen.c
@@ -111,20 +111,11 @@ static void
 }
 
 static void
-    momentum_app_scene_interface_lockscreen_lockscreen_fast_unlock_changed(VariableItem* item) {
+    momentum_app_scene_interface_lockscreen_lockscreen_skip_animation_changed(VariableItem* item) {
     MomentumApp* app = variable_item_get_context(item);
     bool value = variable_item_get_current_value_index(item);
     variable_item_set_current_value_text(item, value ? "ON" : "OFF");
-    momentum_settings.lockscreen_fast_unlock = value;
-    app->save_settings = true;
-}
-
-static void
-    momentum_app_scene_interface_lockscreen_lockscreen_fast_lock_changed(VariableItem* item) {
-    MomentumApp* app = variable_item_get_context(item);
-    bool value = variable_item_get_current_value_index(item);
-    variable_item_set_current_value_text(item, value ? "ON" : "OFF");
-    momentum_settings.lockscreen_fast_lock = value;
+    momentum_settings.lockscreen_skip_animation = value;
     app->save_settings = true;
 }
 
@@ -240,23 +231,13 @@ void momentum_app_scene_interface_lockscreen_on_enter(void* context) {
 
     item = variable_item_list_add(
         var_item_list,
-        "Fast Unlock",
+        "Skip Sliding Animation",
         2,
-        momentum_app_scene_interface_lockscreen_lockscreen_fast_unlock_changed,
+        momentum_app_scene_interface_lockscreen_lockscreen_skip_animation_changed,
         app);
-    variable_item_set_current_value_index(item, momentum_settings.lockscreen_fast_unlock);
+    variable_item_set_current_value_index(item, momentum_settings.lockscreen_skip_animation);
     variable_item_set_current_value_text(
-        item, momentum_settings.lockscreen_fast_unlock ? "ON" : "OFF");
-
-    item = variable_item_list_add(
-        var_item_list,
-        "Fast Lock",
-        2,
-        momentum_app_scene_interface_lockscreen_lockscreen_fast_lock_changed,
-        app);
-    variable_item_set_current_value_index(item, momentum_settings.lockscreen_fast_lock);
-    variable_item_set_current_value_text(
-        item, momentum_settings.lockscreen_fast_lock ? "ON" : "OFF");
+        item, momentum_settings.lockscreen_skip_animation ? "ON" : "OFF");
 
     variable_item_list_set_enter_callback(
         var_item_list, momentum_app_scene_interface_lockscreen_var_item_list_callback, app);

--- a/applications/services/desktop/views/desktop_view_locked.c
+++ b/applications/services/desktop/views/desktop_view_locked.c
@@ -289,7 +289,7 @@ void desktop_view_locked_close_cover(DesktopViewLocked* locked_view) {
     DesktopViewLockedModel* model = view_get_model(locked_view->view);
     furi_assert(model->view_state == DesktopViewLockedStateLocked);
 
-    if(momentum_settings.lockscreen_fast_lock) {
+    if(momentum_settings.lockscreen_skip_animation) {
         locked_view->callback(DesktopLockedEventCoversClosed, locked_view->context);
         model->cover_offset = COVER_OFFSET_END;
         view_commit_model(locked_view->view, true);
@@ -313,7 +313,7 @@ void desktop_view_locked_unlock(DesktopViewLocked* locked_view) {
     locked_view->lock_count = 0;
     DesktopViewLockedModel* model = view_get_model(locked_view->view);
 
-    if(momentum_settings.lockscreen_fast_unlock) {
+    if(momentum_settings.lockscreen_skip_animation) {
         model->view_state = DesktopViewLockedStateUnlocked;
         model->cover_offset = COVER_OFFSET_START;
         model->pin_locked = false;

--- a/applications/services/desktop/views/desktop_view_locked.c
+++ b/applications/services/desktop/views/desktop_view_locked.c
@@ -288,10 +288,17 @@ void desktop_view_locked_free(DesktopViewLocked* locked_view) {
 void desktop_view_locked_close_cover(DesktopViewLocked* locked_view) {
     DesktopViewLockedModel* model = view_get_model(locked_view->view);
     furi_assert(model->view_state == DesktopViewLockedStateLocked);
-    model->view_state = DesktopViewLockedStateCoverClosing;
-    model->cover_offset = COVER_OFFSET_START;
-    view_commit_model(locked_view->view, true);
-    furi_timer_start(locked_view->timer, COVER_MOVING_INTERVAL_MS);
+
+    if(momentum_settings.lockscreen_fast_lock) {
+        locked_view->callback(DesktopLockedEventCoversClosed, locked_view->context);
+        model->cover_offset = COVER_OFFSET_END;
+        view_commit_model(locked_view->view, true);
+    } else {
+        model->view_state = DesktopViewLockedStateCoverClosing;
+        model->cover_offset = COVER_OFFSET_START;
+        view_commit_model(locked_view->view, true);
+        furi_timer_start(locked_view->timer, COVER_MOVING_INTERVAL_MS);
+    }
 }
 
 void desktop_view_locked_lock(DesktopViewLocked* locked_view, bool pin_locked) {
@@ -305,11 +312,19 @@ void desktop_view_locked_lock(DesktopViewLocked* locked_view, bool pin_locked) {
 void desktop_view_locked_unlock(DesktopViewLocked* locked_view) {
     locked_view->lock_count = 0;
     DesktopViewLockedModel* model = view_get_model(locked_view->view);
-    model->view_state = DesktopViewLockedStateCoverOpening;
-    model->cover_offset = COVER_OFFSET_END;
-    model->pin_locked = false;
-    view_commit_model(locked_view->view, true);
-    furi_timer_start(locked_view->timer, COVER_MOVING_INTERVAL_MS);
+
+    if(momentum_settings.lockscreen_fast_unlock) {
+        model->view_state = DesktopViewLockedStateUnlocked;
+        model->cover_offset = COVER_OFFSET_START;
+        model->pin_locked = false;
+        view_commit_model(locked_view->view, true);
+    } else {
+        model->view_state = DesktopViewLockedStateCoverOpening;
+        model->cover_offset = COVER_OFFSET_END;
+        model->pin_locked = false;
+        view_commit_model(locked_view->view, true);
+        furi_timer_start(locked_view->timer, COVER_MOVING_INTERVAL_MS);
+    }
 }
 
 bool desktop_view_locked_is_locked_hint_visible(DesktopViewLocked* locked_view) {

--- a/lib/momentum/settings.c
+++ b/lib/momentum/settings.c
@@ -96,6 +96,8 @@ static const struct {
     {setting_bool(lockscreen_statusbar)},
     {setting_bool(lockscreen_prompt)},
     {setting_bool(lockscreen_transparent)},
+    {setting_bool(lockscreen_fast_unlock)},
+    {setting_bool(lockscreen_fast_lock)},
     {setting_enum(battery_icon, BatteryIconCount)},
     {setting_bool(status_icons)},
     {setting_bool(bar_borders)},

--- a/lib/momentum/settings.c
+++ b/lib/momentum/settings.c
@@ -23,6 +23,7 @@ MomentumSettings momentum_settings = {
     .lockscreen_statusbar = true, // ON
     .lockscreen_prompt = true, // ON
     .lockscreen_transparent = false, // OFF
+    .lockscreen_skip_animation = false, // OFF
     .battery_icon = BatteryIconBarPercent, // Bar %
     .status_icons = true, // ON
     .bar_borders = true, // ON
@@ -96,8 +97,7 @@ static const struct {
     {setting_bool(lockscreen_statusbar)},
     {setting_bool(lockscreen_prompt)},
     {setting_bool(lockscreen_transparent)},
-    {setting_bool(lockscreen_fast_unlock)},
-    {setting_bool(lockscreen_fast_lock)},
+    {setting_bool(lockscreen_skip_animation)},
     {setting_enum(battery_icon, BatteryIconCount)},
     {setting_bool(status_icons)},
     {setting_bool(bar_borders)},

--- a/lib/momentum/settings.h
+++ b/lib/momentum/settings.h
@@ -80,6 +80,8 @@ typedef struct {
     bool lockscreen_statusbar;
     bool lockscreen_prompt;
     bool lockscreen_transparent;
+    bool lockscreen_fast_unlock;
+    bool lockscreen_fast_lock;
     BatteryIcon battery_icon;
     bool status_icons;
     bool bar_borders;

--- a/lib/momentum/settings.h
+++ b/lib/momentum/settings.h
@@ -80,8 +80,7 @@ typedef struct {
     bool lockscreen_statusbar;
     bool lockscreen_prompt;
     bool lockscreen_transparent;
-    bool lockscreen_fast_unlock;
-    bool lockscreen_fast_lock;
+    bool lockscreen_skip_animation;
     BatteryIcon battery_icon;
     bool status_icons;
     bool bar_borders;


### PR DESCRIPTION
# What's new

- The cover animation takes time and blocks input while animating
  - This blocks using desktop keybinds after unlocking, until the animation finishes
- This PR adds an option to skip those animations via the Momentum Settings app
  - Momentum -> Interface -> Lockscreen
  - A new option is added: Skip Sliding Animations

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable
