### PR TITLE
Desktop: Fix lock screen hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixed:
 - Bad KB: Fix modifier keys with HOLD/RELEASE commands (by @WillyJL)
+- Desktop: Fix lock screen hang (#438 by @aaronjamt & @WillyJL)
 
 ### Removed:
 - Nothing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Fixed:
 - Bad KB: Fix modifier keys with HOLD/RELEASE commands (by @WillyJL)
-- Desktop: Fix lock screen hang (#438 by @aaronjamt & @WillyJL)
+- Desktop: Fix lock screen hang (#438 by @aaronjamt)
 
 ### Removed:
 - Nothing

--- a/applications/services/desktop/scenes/desktop_scene_locked.c
+++ b/applications/services/desktop/scenes/desktop_scene_locked.c
@@ -102,7 +102,7 @@ bool desktop_scene_locked_on_event(void* context, SceneManagerEvent event) {
         case DesktopLockedEventUpdate:
             if(desktop_view_locked_is_locked_hint_visible(desktop->locked_view)) {
                 notification_message(
-                    desktop->notification, &sequence_display_backlight_off_delay_1000);
+                    desktop->notification, &sequence_display_backlight_off);
             }
             desktop_view_locked_update(desktop->locked_view);
             consumed = true;

--- a/applications/services/desktop/scenes/desktop_scene_locked.c
+++ b/applications/services/desktop/scenes/desktop_scene_locked.c
@@ -101,8 +101,7 @@ bool desktop_scene_locked_on_event(void* context, SceneManagerEvent event) {
             break;
         case DesktopLockedEventUpdate:
             if(desktop_view_locked_is_locked_hint_visible(desktop->locked_view)) {
-                notification_message(
-                    desktop->notification, &sequence_display_backlight_off);
+                notification_message(desktop->notification, &sequence_display_backlight_off);
             }
             desktop_view_locked_update(desktop->locked_view);
             consumed = true;

--- a/applications/services/desktop/scenes/desktop_scene_locked.c
+++ b/applications/services/desktop/scenes/desktop_scene_locked.c
@@ -102,7 +102,7 @@ bool desktop_scene_locked_on_event(void* context, SceneManagerEvent event) {
         case DesktopLockedEventUpdate:
             if(desktop_view_locked_is_locked_hint_visible(desktop->locked_view)) {
                 notification_message(
-                    desktop->notification, &sequence_display_backlight_off);
+                    desktop->notification, &sequence_display_backlight_off_delay_1000);
             }
             desktop_view_locked_update(desktop->locked_view);
             consumed = true;

--- a/applications/services/desktop/views/desktop_view_locked.c
+++ b/applications/services/desktop/views/desktop_view_locked.c
@@ -316,6 +316,5 @@ bool desktop_view_locked_is_locked_hint_visible(DesktopViewLocked* locked_view) 
     DesktopViewLockedModel* model = view_get_model(locked_view->view);
     const DesktopViewLockedState view_state = model->view_state;
     view_commit_model(locked_view->view, false);
-    return view_state == DesktopViewLockedStateLockedHintShown ||
-           view_state == DesktopViewLockedStateLocked;
+    return view_state == DesktopViewLockedStateLockedHintShown;
 }

--- a/applications/services/desktop/views/desktop_view_locked.c
+++ b/applications/services/desktop/views/desktop_view_locked.c
@@ -316,5 +316,6 @@ bool desktop_view_locked_is_locked_hint_visible(DesktopViewLocked* locked_view) 
     DesktopViewLockedModel* model = view_get_model(locked_view->view);
     const DesktopViewLockedState view_state = model->view_state;
     view_commit_model(locked_view->view, false);
-    return view_state == DesktopViewLockedStateLockedHintShown;
+    return view_state == DesktopViewLockedStateLockedHintShown ||
+           view_state == DesktopViewLockedStateLocked;
 }


### PR DESCRIPTION
# What's new

- Randomly, but fairly often, pressing the Up button on the lock screen will show the pin dialog, but will lock up and not accept input for anywhere from 1-10 seconds. 
- This PR fixes this issue by removing the additional delay from the notification sequence.
  - This delay does not exist in OFW.

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable
