### PR TITLE
Replace commas with dashes to avoid naming errors

### DIFF
--- a/lib/toolbox/name_generator.c
+++ b/lib/toolbox/name_generator.c
@@ -115,7 +115,7 @@ void name_generator_make_detailed_datetime(
             snprintf(
                 name,
                 max_name_size,
-                "%.4d-%.2d-%.2d_%.2d,%.2d,%.2d_%s",
+                "%.4d-%.2d-%.2d_%.2d-%.2d-%.2d_%s",
                 dateTime.year,
                 dateTime.month,
                 dateTime.day,
@@ -127,7 +127,7 @@ void name_generator_make_detailed_datetime(
             snprintf(
                 name,
                 max_name_size,
-                "%s_%.4d-%.2d-%.2d_%.2d,%.2d,%.2d",
+                "%s_%.4d-%.2d-%.2d_%.2d-%.2d-%.2d",
                 prefix,
                 dateTime.year,
                 dateTime.month,
@@ -140,7 +140,7 @@ void name_generator_make_detailed_datetime(
         snprintf(
             name,
             max_name_size,
-            "%.4d-%.2d-%.2d_%.2d,%.2d,%.2d",
+            "%.4d-%.2d-%.2d_%.2d-%.2d-%.2d",
             dateTime.year,
             dateTime.month,
             dateTime.day,


### PR DESCRIPTION
According to lab.flipper.net, files are not allowed to contain commas. It displays an error right when you click rename on files. To avoid this error, it would be good to replace comma with dashes.

## Example

<img width="379" height="203" alt="image" src="https://github.com/user-attachments/assets/2c38ff12-3126-4f63-965b-6f54a8ab5f4c" />

<img width="369" height="195" alt="image" src="https://github.com/user-attachments/assets/3201ae97-c6f0-4424-97b4-4977f7a3b824" />

# What's new

- Replaced commas with dashes

-----
# For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ ] I've confirmed the bug to be fixed / feature to be stable
