### PR TITLE
Allow building the firmware with the SubGHz protocol items disabled

### DIFF
--- a/applications/main/subghz/helpers/subghz_gen_info.c
+++ b/applications/main/subghz/helpers/subghz_gen_info.c
@@ -1,6 +1,19 @@
 #include "subghz_gen_info.h"
 #include "../helpers/subghz_txrx_create_protocol_key.h"
-#include <lib/subghz/protocols/protocol_items.h>
+#include <lib/subghz/protocols/princeton.h>
+#include <lib/subghz/protocols/nice_flo.h>
+#include <lib/subghz/protocols/came.h>
+#include <lib/subghz/protocols/roger.h>
+#include <lib/subghz/protocols/linear.h>
+#include <lib/subghz/protocols/bett.h>
+#include <lib/subghz/protocols/came_twee.h>
+#include <lib/subghz/protocols/gate_tx.h>
+#include <lib/subghz/protocols/gangqi.h>
+#include <lib/subghz/protocols/hollarm.h>
+#include <lib/subghz/protocols/revers_rb2.h>
+#include <lib/subghz/protocols/marantec24.h>
+#include <lib/subghz/protocols/marantec.h>
+#include <lib/subghz/blocks/math.h>
 
 void subghz_gen_info_reset(GenInfo* gen_info) {
     furi_assert(gen_info);

--- a/applications/main/subghz/helpers/subghz_txrx.c
+++ b/applications/main/subghz/helpers/subghz_txrx.c
@@ -1,6 +1,7 @@
 #include "subghz_txrx_i.h" // IWYU pragma: keep
 
-#include <lib/subghz/protocols/protocol_items.h>
+#include <lib/subghz/subghz_protocol_registry.h>
+#include <lib/subghz/protocols/public_api.h>
 #include <applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h>
 #include <lib/subghz/devices/cc1101_int/cc1101_int_interconnect.h>
 #include <lib/subghz/blocks/custom_btn.h>

--- a/applications/main/subghz/helpers/subghz_txrx_create_protocol_key.c
+++ b/applications/main/subghz/helpers/subghz_txrx_create_protocol_key.c
@@ -1,7 +1,11 @@
 #include "subghz_txrx_i.h" // IWYU pragma: keep
 #include "subghz_txrx_create_protocol_key.h"
 #include <lib/subghz/transmitter.h>
-#include <lib/subghz/protocols/protocol_items.h>
+#include <lib/subghz/protocols/faac_slh.h>
+#include <lib/subghz/protocols/alutech_at_4n.h>
+#include <lib/subghz/protocols/came_atomo.h>
+#include <lib/subghz/protocols/somfy_telis.h>
+#include <lib/subghz/protocols/phoenix_v2.h>
 #include <lib/subghz/protocols/keeloq.h>
 #include <lib/subghz/protocols/secplus_v1.h>
 #include <lib/subghz/protocols/secplus_v2.h>


### PR DESCRIPTION
# What's new

In order to fit large protocol decoders/encoders, some of the others need to be disabled in order to meet the flash size limit. But some of the code relied on them always enabled.

This patch fixes it by including the relevant headers instead of assuming that all SubGHz protocols are enabled at all time.

Tested building with all protocols disabled, SubGHz Read and Read raw crash because of furi_check(). By enabling just raw and bin_raw, both options work again.

No functional change is expected by this commit.

-----
# For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ ] I've confirmed the bug to be fixed / feature to be stable
