### PR TITLE
Add MFC "Show Keys" UI

### DIFF
--- a/applications/main/nfc/helpers/protocol_support/mf_classic/mf_classic.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_classic/mf_classic.c
@@ -15,6 +15,7 @@ enum {
     SubmenuIndexDictAttack,
     SubmenuIndexCrackNonces,
     SubmenuIndexUpdate,
+    SubmenuIndexShowKeys,
 };
 
 static void nfc_scene_info_on_enter_mf_classic(NfcApp* instance) {
@@ -138,6 +139,13 @@ static void nfc_scene_read_menu_on_enter_mf_classic(NfcApp* instance) {
             SubmenuIndexCrackNonces,
             nfc_protocol_support_common_submenu_callback,
             instance);
+
+        submenu_add_item(
+            submenu,
+            "Show Keys",
+            SubmenuIndexShowKeys,
+            nfc_protocol_support_common_submenu_callback,
+            instance);
     }
 }
 
@@ -176,6 +184,13 @@ static void nfc_scene_saved_menu_on_enter_mf_classic(NfcApp* instance) {
             submenu,
             "Unlock with Dictionary",
             SubmenuIndexDictAttack,
+            nfc_protocol_support_common_submenu_callback,
+            instance);
+
+        submenu_add_item(
+            submenu,
+            "Show Keys",
+            SubmenuIndexShowKeys,
             nfc_protocol_support_common_submenu_callback,
             instance);
     }
@@ -218,6 +233,9 @@ static bool nfc_scene_read_menu_on_event_mf_classic(NfcApp* instance, SceneManag
                 instance->scene_manager, NfcSceneSaveConfirm, NfcSceneSaveConfirmStateCrackNonces);
             scene_manager_next_scene(instance->scene_manager, NfcSceneSaveConfirm);
             consumed = true;
+        } else if(event.event == SubmenuIndexShowKeys) {
+            scene_manager_next_scene(instance->scene_manager, NfcSceneMfClassicShowKeys);
+            consumed = true;
         }
     }
 
@@ -239,6 +257,9 @@ static bool nfc_scene_saved_menu_on_event_mf_classic(NfcApp* instance, SceneMana
             consumed = true;
         } else if(event.event == SubmenuIndexUpdate) {
             scene_manager_next_scene(instance->scene_manager, NfcSceneMfClassicUpdateInitial);
+            consumed = true;
+        } else if(event.event == SubmenuIndexShowKeys) {
+            scene_manager_next_scene(instance->scene_manager, NfcSceneMfClassicShowKeys);
             consumed = true;
         }
     }

--- a/applications/main/nfc/scenes/nfc_scene_config.h
+++ b/applications/main/nfc/scenes/nfc_scene_config.h
@@ -46,6 +46,7 @@ ADD_SCENE(nfc, mf_classic_mfkey_complete, MfClassicMfkeyComplete)
 ADD_SCENE(nfc, mf_classic_update_initial, MfClassicUpdateInitial)
 ADD_SCENE(nfc, mf_classic_update_initial_success, MfClassicUpdateInitialSuccess)
 ADD_SCENE(nfc, mf_classic_update_initial_wrong_card, MfClassicUpdateInitialWrongCard)
+ADD_SCENE(nfc, mf_classic_show_keys, MfClassicShowKeys)
 
 ADD_SCENE(nfc, mf_classic_keys, MfClassicKeys)
 ADD_SCENE(nfc, mf_classic_keys_list, MfClassicKeysList)

--- a/applications/main/nfc/scenes/nfc_scene_mf_classic_show_keys.c
+++ b/applications/main/nfc/scenes/nfc_scene_mf_classic_show_keys.c
@@ -1,0 +1,68 @@
+#include "../nfc_app_i.h"
+
+#include <bit_lib/bit_lib.h>
+#include <dolphin/dolphin.h>
+
+#define TAG "NfcMfClassicShowKeys"
+
+void nfc_scene_mf_classic_show_keys_on_enter(void* context) {
+    NfcApp* instance = context;
+
+    const MfClassicData* mfc_data =
+        nfc_device_get_data(instance->nfc_device, NfcProtocolMfClassic);
+
+    furi_string_printf(instance->text_box_store, "Found MFC Keys:");
+
+    uint8_t num_sectors = mf_classic_get_total_sectors_num(mfc_data->type);
+    uint8_t found_keys_a = 0, found_keys_b = 0;
+    for(uint8_t i = 0; i < num_sectors; i++) {
+        MfClassicSectorTrailer* sec_tr = mf_classic_get_sector_trailer_by_sector(mfc_data, i);
+
+        bool key_a = FURI_BIT(mfc_data->key_a_mask, i);
+        bool key_b = FURI_BIT(mfc_data->key_b_mask, i);
+
+        if(key_a || key_b) {
+            furi_string_cat_printf(instance->text_box_store, "\nSector %d [AC:", i);
+            for(uint8_t j = 0; j < MF_CLASSIC_ACCESS_BYTES_SIZE; j++)
+                furi_string_cat_printf(
+                    instance->text_box_store, " %02X", sec_tr->access_bits.data[j]);
+            furi_string_cat_printf(instance->text_box_store, "]");
+        }
+
+        if(key_a) {
+            found_keys_a++;
+            furi_string_cat_printf(instance->text_box_store, "\n -> A:");
+            for(uint8_t j = 0; j < MF_CLASSIC_KEY_SIZE; j++)
+                furi_string_cat_printf(instance->text_box_store, " %02X", sec_tr->key_a.data[j]);
+        }
+        if(key_b) {
+            found_keys_b++;
+            furi_string_cat_printf(instance->text_box_store, "\n -> B:");
+            for(uint8_t j = 0; j < MF_CLASSIC_KEY_SIZE; j++)
+                furi_string_cat_printf(instance->text_box_store, " %02X", sec_tr->key_b.data[j]);
+        }
+    }
+
+    furi_string_cat_printf(
+        instance->text_box_store,
+        "\nTotal keys found:\n -> %d/%d A keys\n -> %d/%d B keys",
+        found_keys_a,
+        num_sectors,
+        found_keys_b,
+        num_sectors);
+
+    text_box_set_text(instance->text_box, furi_string_get_cstr(instance->text_box_store));
+    view_dispatcher_switch_to_view(instance->view_dispatcher, NfcViewTextBox);
+}
+
+bool nfc_scene_mf_classic_show_keys_on_event(void* context, SceneManagerEvent event) {
+    UNUSED(context);
+    UNUSED(event);
+    return false;
+}
+
+void nfc_scene_mf_classic_show_keys_on_exit(void* context) {
+    NfcApp* instance = context;
+    text_box_reset(instance->text_box);
+    furi_string_reset(instance->text_box_store);
+}


### PR DESCRIPTION
# Superseded by #473 

-----

## What's new

- Add new option to show keys for MFC tags
- Closes #467 

<details>
<summary>Image showing option in "Info" menu</summary>
<img width="822" height="418" alt="image" src="https://github.com/user-attachments/assets/276756e2-7392-406a-a5c4-3a0cf0d22fd9" />
</details>

<details>
<summary>Image showing new "Show Keys" UI</summary>
Note that it only shows sectors the keys are known for (in this case, skipping sector 1) and also shows the access bits for the sector.
<img width="816" height="415" alt="image" src="https://github.com/user-attachments/assets/7c71e52b-0fce-4f59-b056-28aa497fd150" />
</details>

-----
## For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ ] I've confirmed the bug to be fixed / feature to be stable
