### PR TITLE
Add MFUL counters to Info page

### DIFF
--- a/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight_render.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight_render.c
@@ -9,6 +9,11 @@ static void nfc_render_mf_ultralight_pages_count(const MfUltralightData* data, F
     }
 }
 
+static void nfc_render_mf_ultralight_counters(const MfUltralightData* data, FuriString* str) {
+    for(uint8_t i = 0; i < MF_ULTRALIGHT_COUNTER_NUM; i++)
+        furi_string_cat_printf(str, "\nCounter %u: %lu", i, data->counter[i].counter);
+}
+
 void nfc_render_mf_ultralight_pwd_pack(const MfUltralightData* data, FuriString* str) {
     MfUltralightConfigPages* config;
 
@@ -44,6 +49,8 @@ void nfc_render_mf_ultralight_info(
     nfc_render_iso14443_3a_info(data->iso14443_3a_data, format_type, str);
 
     nfc_render_mf_ultralight_pages_count(data, str);
+
+    nfc_render_mf_ultralight_counters(data, str);
 }
 
 void nfc_render_mf_ultralight_dump(const MfUltralightData* data, FuriString* str) {


### PR DESCRIPTION
# Superseded by #472 

-----

## What's new

- Adds the Counter fields to the Info page for Mifare Ultralight cards
- Resolves #444

-----
## For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ ] I've confirmed the bug to be fixed / feature to be stable
