### PR TITLE
NFC: Handle PPS request in ISO14443-4 layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,7 +149,7 @@
   - RFID/iButton Fuzzer: Fix prev navigation for custom UIDs (by @ahnilica)
   - Seader: Fix ATS handling (by @NVX), reset SAM on error, support config card, code optimizations, use same commands as Proxmark3, distinguish SIO SE/SR (by @bettse)
   - Sentry Safe: New interface, settings & help page (by @H4ckd4ddy)
-  - Seos Compatible: Add keys v2 support with per-device encryption, improve logging (by @bettse), BLE fixes (by @aaronjamt)
+  - Seos Compatible: Add keys v2 support with per-device encryption, improve logging (by @bettse), BLE fixes, code cleanup (by @aaronjamt), compatibility with NFC Type 4 PR 4242 (by @WillyJL)
   - Sub-GHz Playlist: Fix crash on disallowed frequencies (by @WillyJL)
   - Weather Station: Added support for solight TE44 (by @fersingb)
   - Weebo: Prevent 0x88 in UID[3], add more figures to the database (by @bettse)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,7 @@
   - Fix incorrect Saflok year formula (#433 by @Eltrick)
   - Fix read crash with unexpectedly large MFC AUTH(0) response, eg with Chameleon Ultra NTAG emualtion (by @WillyJL)
   - Fix slashes in prefilled filename (by @WillyJL)
+  - Handle PPS request in ISO14443-4 layer (by @WillyJL)
 - FBT: Fix redundant decl for apps using an icon disabled in API (by @WillyJL)
 - UL: Sub-GHz: Fix crash in add manually menu (by @xMasterX)
 - Clangd: Add clangd parameters in IDE agnostic config file (by @WillyJL)


### PR DESCRIPTION
# What's new

- PPS handled in ISO14443-4 layer, should help with SEOS app compatibility

-----
# For the reviewer

- [x] I've uploaded the firmware with this patch to a device and verified its functionality
- [x] I've confirmed the bug to be fixed / feature to be stable
