### PR TITLE
NFC: Enable writing button for ULC and NTAG I2C

### DIFF
--- a/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight.c
+++ b/applications/main/nfc/helpers/protocol_support/mf_ultralight/mf_ultralight.c
@@ -211,10 +211,8 @@ static void nfc_scene_read_and_saved_menu_on_enter_mf_ultralight(NfcApp* instanc
         nfc_device_get_data(instance->nfc_device, NfcProtocolMfUltralight);
     bool is_locked = !mf_ultralight_is_all_data_read(data);
 
-    if(is_locked ||
-       (data->type != MfUltralightTypeNTAG213 && data->type != MfUltralightTypeNTAG215 &&
-        data->type != MfUltralightTypeNTAG216 && data->type != MfUltralightTypeUL11 &&
-        data->type != MfUltralightTypeUL21 && data->type != MfUltralightTypeOrigin)) {
+    // FIXME: need to test if writing works on ULC and NTAG I2C
+    if(is_locked) {
         submenu_remove_item(submenu, SubmenuIndexCommonWrite);
     }
 


### PR DESCRIPTION
# What's new

Enables writing for MIFARE Ultralight C and NTAG I2C cards. Currently not tested whether writing to them works, just the button is now visible and clickable.

- Enables the writing button for all MIFARE Ultralight types, while before only basic Ultralight and NTAGs had it enabled

-----
# For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ ] I've confirmed the bug to be fixed / feature to be stable
