### PR TITLE
enables BLE Central capabilities

### DIFF
--- a/applications/services/bt/bt_service/bt.c
+++ b/applications/services/bt/bt_service/bt.c
@@ -501,14 +501,16 @@ static void bt_handle_get_settings(Bt* bt, BtMessage* message) {
 
 static void bt_handle_set_settings(Bt* bt, BtMessage* message) {
     bt->bt_settings = *message->data.csettings;
+    furi_hal_bt_set_central_mode(bt->bt_settings.central_mode);
     bt_apply_settings(bt);
     bt_settings_save(&bt->bt_settings);
 }
 
 static void bt_handle_reload_keys_settings(Bt* bt) {
     bt_load_keys(bt);
-    bt_start_application(bt);
     bt_load_settings(bt);
+    furi_hal_bt_set_central_mode(bt->bt_settings.central_mode);
+    bt_start_application(bt);
 }
 
 static void bt_init_keys_settings(Bt* bt) {

--- a/applications/services/bt/bt_settings.c
+++ b/applications/services/bt/bt_settings.c
@@ -8,7 +8,7 @@
 
 #define TAG "BtSettings"
 
-#define BT_SETTINGS_VERSION (0)
+#define BT_SETTINGS_VERSION (1)
 #define BT_SETTINGS_MAGIC   (0x19)
 
 void bt_settings_load(BtSettings* bt_settings) {
@@ -21,6 +21,7 @@ void bt_settings_load(BtSettings* bt_settings) {
         FURI_LOG_W(TAG, "Failed to load settings, using defaults");
 
         bt_settings->enabled = false;
+        bt_settings->central_mode = false;
         // bt_settings_save(bt_settings);
     }
 }

--- a/applications/services/bt/bt_settings.h
+++ b/applications/services/bt/bt_settings.h
@@ -8,6 +8,7 @@ extern "C" {
 
 typedef struct {
     bool enabled;
+    bool central_mode;
 } BtSettings;
 
 void bt_settings_load(BtSettings* bt_settings);

--- a/applications/settings/bt_settings_app/scenes/bt_settings_scene_start.c
+++ b/applications/settings/bt_settings_app/scenes/bt_settings_scene_start.c
@@ -9,6 +9,7 @@ enum BtSetting {
 
 enum BtSettingIndex {
     BtSettingIndexSwitchBt,
+    BtSettingIndexCentralMode,
     BtSettingIndexForgetDev,
 };
 
@@ -23,6 +24,14 @@ static void bt_settings_scene_start_var_list_change_callback(VariableItem* item)
 
     variable_item_set_current_value_text(item, bt_settings_text[index]);
     view_dispatcher_send_custom_event(app->view_dispatcher, index);
+}
+
+static void bt_settings_scene_start_central_mode_change_callback(VariableItem* item) {
+    BtSettingsApp* app = variable_item_get_context(item);
+    uint8_t index = variable_item_get_current_value_index(item);
+
+    variable_item_set_current_value_text(item, bt_settings_text[index]);
+    view_dispatcher_send_custom_event(app->view_dispatcher, BtSettingIndexCentralMode);
 }
 
 static void bt_settings_scene_start_var_list_enter_callback(void* context, uint32_t index) {
@@ -53,6 +62,21 @@ void bt_settings_scene_start_on_enter(void* context) {
             variable_item_set_current_value_index(item, BtSettingOff);
             variable_item_set_current_value_text(item, bt_settings_text[BtSettingOff]);
         }
+
+        item = variable_item_list_add(
+            var_item_list,
+            "BLE Central",
+            BtSettingNum,
+            bt_settings_scene_start_central_mode_change_callback,
+            app);
+        if(app->settings.central_mode) {
+            variable_item_set_current_value_index(item, BtSettingOn);
+            variable_item_set_current_value_text(item, bt_settings_text[BtSettingOn]);
+        } else {
+            variable_item_set_current_value_index(item, BtSettingOff);
+            variable_item_set_current_value_text(item, bt_settings_text[BtSettingOff]);
+        }
+
         variable_item_list_add(var_item_list, "Unpair All Devices", 1, NULL, NULL);
         variable_item_list_set_enter_callback(
             var_item_list, bt_settings_scene_start_var_list_enter_callback, app);
@@ -74,6 +98,9 @@ bool bt_settings_scene_start_on_event(void* context, SceneManagerEvent event) {
             consumed = true;
         } else if(event.event == BtSettingOff) {
             app->settings.enabled = false;
+            consumed = true;
+        } else if(event.event == BtSettingIndexCentralMode) {
+            app->settings.central_mode = !app->settings.central_mode;
             consumed = true;
         } else if(event.event == BtSettingsCustomEventForgetDevices) {
             scene_manager_next_scene(app->scene_manager, BtSettingsAppSceneForgetDevConfirm);

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -1394,6 +1394,7 @@ Function,+,furi_hal_bt_lock_core2,void,
 Function,+,furi_hal_bt_nvm_sram_sem_acquire,void,
 Function,+,furi_hal_bt_nvm_sram_sem_release,void,
 Function,+,furi_hal_bt_reinit,void,
+Function,+,furi_hal_bt_set_central_mode,void,_Bool
 Function,+,furi_hal_bt_set_key_storage_change_callback,void,"BleGlueKeyStorageChangedCallback, void*"
 Function,+,furi_hal_bt_start_advertising,void,
 Function,+,furi_hal_bt_start_app,FuriHalBleProfileBase*,"const FuriHalBleProfileTemplate*, FuriHalBleProfileParams, const GapRootSecurityKeys*, GapEventCallback, void*"
@@ -2081,7 +2082,7 @@ Function,+,gui_set_lockdown,void,"Gui*, _Bool"
 Function,+,gui_set_lockdown_inhibit,void,"Gui*, _Bool"
 Function,-,gui_view_port_send_to_back,void,"Gui*, ViewPort*"
 Function,+,gui_view_port_send_to_front,void,"Gui*, ViewPort*"
-Function,-,hci_send_req,int,"hci_request*, uint8_t"
+Function,+,hci_send_req,int,"hci_request*, uint8_t"
 Function,+,hex_char_to_hex_nibble,_Bool,"char, uint8_t*"
 Function,+,hex_char_to_uint8,_Bool,"char, char, uint8_t*"
 Function,+,hex_chars_to_uint64,_Bool,"const char*, uint64_t*"

--- a/targets/f7/ble_glue/gap.c
+++ b/targets/f7/ble_glue/gap.c
@@ -53,6 +53,8 @@ typedef enum {
 
 static Gap* gap = NULL;
 
+void gap_force_include_central_symbols(void);
+
 static void gap_advertise_start(GapState new_state);
 static int32_t gap_app(void* context);
 
@@ -151,6 +153,15 @@ BleEventFlowStatus ble_event_app_notification(void* pckt) {
     case HCI_LE_META_EVT_CODE:
         meta_evt = (evt_le_meta_event*)event_pckt->data;
         switch(meta_evt->subevent) {
+        case HCI_LE_ADVERTISING_REPORT_SUBEVT_CODE: {
+            GapEvent event = {
+                .type = GapEventTypeAdvReport,
+                .data.data = meta_evt->data,
+            };
+            gap->on_event_cb(event, gap->context);
+            break;
+        }
+
         case HCI_LE_CONNECTION_UPDATE_COMPLETE_SUBEVT_CODE: {
             hci_le_connection_update_complete_event_rp0* event =
                 (hci_le_connection_update_complete_event_rp0*)meta_evt->data;
@@ -193,10 +204,16 @@ BleEventFlowStatus ble_event_app_notification(void* pckt) {
             gap->service.connection_handle = event->Connection_Handle;
 
             gap_verify_connection_parameters(gap);
-            if(gap->config->pairing_method != GapPairingNone) {
+            if(gap->config->pairing_method != GapPairingNone && event->Role == 0x01) {
                 // Start pairing by sending security request
                 aci_gap_slave_security_req(event->Connection_Handle);
             }
+
+            GapEvent gap_event = {
+                .type = GapEventTypeConnectionComplete,
+                .data.data = event,
+            };
+            gap->on_event_cb(gap_event, gap->context);
         } break;
 
         default:
@@ -357,7 +374,8 @@ static void gap_init_svc(Gap* gap, const GapRootSecurityKeys* root_keys) {
     // Skip fist symbol AD_TYPE_COMPLETE_LOCAL_NAME
     char* name = gap->service.adv_name + 1;
     aci_gap_init(
-        GAP_PERIPHERAL_ROLE,
+        gap->config->central_mode ? (GAP_CENTRAL_ROLE | GAP_PERIPHERAL_ROLE) :
+                                    GAP_PERIPHERAL_ROLE,
         0,
         strlen(name),
         &gap->service.gap_svc_handle,
@@ -548,6 +566,7 @@ bool gap_init(
     // Initialization of GATT & GAP layer
     gap->service.adv_name = config->adv_name;
     gap_init_svc(gap, root_keys);
+    gap_force_include_central_symbols();
     ble_event_dispatcher_init();
     // Initialization of the GAP state
     gap->state_mutex = furi_mutex_alloc(FuriMutexTypeNormal);
@@ -659,4 +678,15 @@ void gap_emit_ble_beacon_status_event(bool active) {
     GapEvent event = {.type = active ? GapEventTypeBeaconStart : GapEventTypeBeaconStop};
     gap->on_event_cb(event, gap->context);
     FURI_LOG_I(TAG, "Beacon status event: %d", active);
+}
+
+// Dummy function to force linker to include Central/Observer functions
+// This is needed because fbt/checks might strip them if unused by firmware
+void __attribute__((used)) gap_force_include_central_symbols(void) {
+    volatile int i = 0;
+    if (i) {
+        aci_gap_start_general_discovery_proc(0, 0, 0, 0);
+        aci_gap_terminate_gap_proc(0);
+        // aci_gap_terminate is already used
+    }
 }

--- a/targets/f7/ble_glue/gap.h
+++ b/targets/f7/ble_glue/gap.h
@@ -26,11 +26,14 @@ typedef enum {
     GapEventTypeUpdateMTU,
     GapEventTypeBeaconStart,
     GapEventTypeBeaconStop,
+    GapEventTypeAdvReport,
+    GapEventTypeConnectionComplete,
 } GapEventType;
 
 typedef union {
     uint32_t pin_code;
     uint16_t max_packet_size;
+    void* data;
 } GapEventData;
 
 typedef struct {
@@ -83,6 +86,7 @@ typedef struct {
     uint8_t mac_address[GAP_MAC_ADDR_SIZE];
     char adv_name[FURI_HAL_VERSION_DEVICE_NAME_LENGTH];
     GapConnectionParamsRequest conn_param;
+    bool central_mode;
 } GapConfig;
 
 typedef struct {

--- a/targets/f7/furi_hal/furi_hal_bt.c
+++ b/targets/f7/furi_hal/furi_hal_bt.c
@@ -38,6 +38,7 @@ static FuriHalBt furi_hal_bt = {
 
 static FuriHalBleProfileBase* current_profile = NULL;
 static GapConfig current_config = {0};
+static bool furi_hal_bt_central_mode_enabled = false;
 
 void furi_hal_bt_init(void) {
     FURI_LOG_I(TAG, "Start BT initialization");
@@ -184,6 +185,7 @@ FuriHalBleProfileBase* furi_hal_bt_start_app(
         }
 
         profile_template->get_gap_config(&current_config, params);
+        current_config.central_mode = furi_hal_bt_central_mode_enabled;
 
         if(!gap_init(&current_config, root_keys, event_cb, context)) {
             gap_thread_stop();
@@ -439,4 +441,8 @@ bool furi_hal_bt_extra_beacon_stop(void) {
 
 bool furi_hal_bt_extra_beacon_is_active(void) {
     return gap_extra_beacon_get_state() == GapExtraBeaconStateStarted;
+}
+
+void furi_hal_bt_set_central_mode(bool enabled) {
+    furi_hal_bt_central_mode_enabled = enabled;
 }

--- a/targets/furi_hal_include/furi_hal_bt.h
+++ b/targets/furi_hal_include/furi_hal_bt.h
@@ -296,6 +296,12 @@ bool furi_hal_bt_extra_beacon_is_active(void);
  */
 const GapExtraBeaconConfig* furi_hal_bt_extra_beacon_get_config(void);
 
+/** Set central mode enabled
+ *
+ * @param[in]  enabled  true to enable central mode
+ */
+void furi_hal_bt_set_central_mode(bool enabled);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
# What's new

This patch enables BLE Central capabilities on the Flipper Zero (Momentum dev firmware). It allows user applications to scan for BLE peripherals and initiate connections by exposing the necessary HCI/GAP interfaces and configuring the stack with the `GAP_CENTRAL_ROLE`.

Changes include:
1.  **Low-Level (HAL/Glue):**
    *   Modified `furi_hal_bt_init` / `gap.c` to accept a central mode flag.
    *   Exported `hci_send_req` and other discovery functions to the SDK.
    *   Ensured advertising reports are forwarded to the event dispatcher.
2.  **User Interface:**
    *   Added a toggle in **Settings -> Bluetooth** to enable/disable "BLE Central".
3.  **Logic:**
    *   Updated `bt_service` to persist this setting and trigger a stack re-initialization upon change, fixing the issue where the toggle would revert or not take effect until a reboot.

-----
# For the reviewer

- [ ] I've uploaded the firmware with this patch to a device but i need other people to confirm BLE Central is working as expected, all is working well, only the features need to be tested and approved/pushed
