### PR TITLE
Update documentation link for HT12A protocol

### DIFF
--- a/lib/subghz/protocols/holtek_ht12x.c
+++ b/lib/subghz/protocols/holtek_ht12x.c
@@ -8,7 +8,7 @@
 
 /*
  * Help
- * https://www.holtek.com/documents/10179/116711/HT12A_Ev130.pdf
+ * https://www.holtek.com/webapi/116711/HT12A_Ev130.pdf
  *
  */
 


### PR DESCRIPTION
Holtec doc no longer available at previous link

# What's new

- Updated holtec .pdf link

-----
# For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ ] I've confirmed the bug to be fixed / feature to be stable
