### PR TITLE
Beninca ARC - Fix hidden button - Should be 0 not FF

### DIFF
--- a/lib/subghz/protocols/beninca_arc.c
+++ b/lib/subghz/protocols/beninca_arc.c
@@ -92,14 +92,14 @@ static uint8_t subghz_protocol_beninca_arc_get_btn_code(void) {
         btn = original_btn_code;
     } else if(custom_btn_id == SUBGHZ_CUSTOM_BTN_UP) {
         switch(original_btn_code) {
+        case 0x00:
+            btn = 0x04;
+            break;
         case 0x02:
             btn = 0x04;
             break;
         case 0x04:
             btn = 0x02;
-            break;
-        case 0xFF:
-            btn = 0x04;
             break;
 
         default:
@@ -107,16 +107,16 @@ static uint8_t subghz_protocol_beninca_arc_get_btn_code(void) {
         }
     } else if(custom_btn_id == SUBGHZ_CUSTOM_BTN_DOWN) {
         switch(original_btn_code) {
-        case 0x02:
-            btn = 0xFF;
-            break;
-        case 0x04:
-            btn = 0xFF;
-            break;
-        case 0xFF:
+        case 0x00:
             btn = 0x02;
             break;
-
+        case 0x02:
+            btn = 0x00;
+            break;
+        case 0x04:
+            btn = 0x00;
+            break;
+        
         default:
             break;
         }


### PR DESCRIPTION
# What's new

When creating new file the down arrow was defaulting to btn value of 0xFF. Having tested with my own hardware the "hidden button" value is actually 0x0.

I have tested code and I am now able to get the receiver to enter programming mode the same as the standard remote.

Remote used for testing was Beninca TO.GO2VA set in ARC mode.

-----
# For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ ] I've confirmed the bug to be fixed / feature to be stable
