### PR TITLE
Update GHA patch levels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         target: [f7]
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.3.1
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,7 +199,7 @@ jobs:
 
       - name: "Wait for deploy (Run ID ${{ steps.force-deploy.outputs.run_id }})"
         if: ${{ env.SHOULD_DEPLOY == 'true' }}
-        uses: Codex-/await-remote-run@v1
+        uses: Codex-/await-remote-run@v1.13.0
         with:
           token: ${{ github.token }}
           repo: v2.momentum-fw.dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
           git diff --exit-code
 
       - name: "Upload artifacts to GitHub"
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4.6.2
         with:
           path: |
             dist/${{ env.TARGET }}-*/flipper-z-${{ env.TARGET }}-update-*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
           git diff --exit-code
 
       - name: "Upload artifacts to GitHub"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.1
         with:
           path: |
             dist/${{ env.TARGET }}-*/flipper-z-${{ env.TARGET }}-update-*

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.3.1
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: "Wait for deploy (Run ID ${{ steps.force-deploy.outputs.run_id }})"
         if: ${{ env.SHOULD_REINDEX == 'true' }}
-        uses: Codex-/await-remote-run@v1
+        uses: Codex-/await-remote-run@v1.13.0
         with:
           token: ${{ github.token }}
           repo: v2.momentum-fw.dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.3.1
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/webhook.yml
+++ b/.github/workflows/webhook.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.3.1
         with:
           fetch-depth: 1
           ref: ${{ github.event.pull_request.head.sha }}

--- a/scripts/ufbt/project_template/app_template/.github/workflows/build.yml
+++ b/scripts/ufbt/project_template/app_template/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           sdk-channel: ${{ matrix.sdk-channel }}
       - name: Upload app artifacts
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4.6.2
         with:
           # See ufbt action docs for other output variables
           name: ${{ github.event.repository.name }}-${{ steps.build-app.outputs.suffix }}

--- a/scripts/ufbt/project_template/app_template/.github/workflows/build.yml
+++ b/scripts/ufbt/project_template/app_template/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           sdk-channel: ${{ matrix.sdk-channel }}
       - name: Upload app artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.1
         with:
           # See ufbt action docs for other output variables
           name: ${{ github.event.repository.name }}-${{ steps.build-app.outputs.suffix }}

--- a/scripts/ufbt/project_template/app_template/.github/workflows/build.yml
+++ b/scripts/ufbt/project_template/app_template/.github/workflows/build.yml
@@ -1,15 +1,15 @@
 name: "FAP: Build for multiple SDK sources"
-# This will build your app for dev and release channels on GitHub. 
+# This will build your app for dev and release channels on GitHub.
 # It will also build your app every day to make sure it's up to date with the latest SDK changes.
 # See https://github.com/marketplace/actions/build-flipper-application-package-fap for more information
 
 on:
   push:
     ## put your main branch name under "branches"
-    #branches: 
-    #  - master 
+    #branches:
+    #  - master
   pull_request:
-  schedule: 
+  schedule:
     # do a build every day
     - cron: "1 1 * * *"
 
@@ -27,7 +27,7 @@ jobs:
     name: 'ufbt: Build for ${{ matrix.name }}'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.3.1
       - name: Build with ufbt
         uses: flipperdevices/flipperzero-ufbt-action@v0.1
         id: build-app


### PR DESCRIPTION
# What's new

I updated the patch level versions of the following GitHub Actions:

```
actions/checkout@v4 => v4.3.1
actions/upload-artifact@v4 => v4.3.1
Codex-/await-remote-run@v1 => v1.13.0
```

My intention for these version bumps is to keep linchpin workflows current for maintenance, dependency updates, and safer, more predictable behavior, without the risk of introducing breaking changes.

-----
# For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ ] I've confirmed the bug to be fixed / feature to be stable
