### PR TITLE
Address utf8 write bug when uploading JavaScript applications to device with fz-sdk

### DIFF
--- a/applications/system/js_app/packages/fz-sdk/sdk.js
+++ b/applications/system/js_app/packages/fz-sdk/sdk.js
@@ -153,10 +153,11 @@ async function upload(config) {
     port.write(`storage remove ${config.output}\x0d`);
     port.drain();
     await waitFor(">: ", 1000);
-    port.write(`storage write_chunk ${config.output} ${appFile.length}\x0d`);
+    const appFileBuffer = Buffer.from(appFile, "utf8");
+    port.write(`storage write_chunk ${config.output} ${appFileBuffer.length}\x0d`);
     await waitFor("Ready", 1000);
-    port.write(appFile);
-    port.drain();
+    port.write(appFileBuffer);
+    await new Promise(resolve => port.drain(resolve));
     await waitFor(">: ", 1000);
 
     console.log("Launching application");


### PR DESCRIPTION
# What's new

- fz-sdk - address a bug in issue # 535 causing characters to continue on to the beginning of the js command when writing utf8 files to the device.

-----
# For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ x ] I've confirmed the bug to be fixed / feature to be stable

*note this was tested against the most recent version of @next-flip/fz-sdk-mntm with success.