### PR TITLE
POC of a dynamic loading system for encoders to save on flash size

### DIFF
--- a/applications/main/subghz/application.fam
+++ b/applications/main/subghz/application.fam
@@ -61,3 +61,13 @@ App(
     # sources=["subghz_extended_freq.c"],
     order=650,
 )
+
+App(
+    appid="subghz_encoder_secplus_v2",
+    name="Security+ 2.0 Encoder",
+    apptype=FlipperAppType.PLUGIN,
+    entry_point="secplus_v2_encoder_plugin_ep",
+    targets=["f7"],
+    requires=["subghz"],
+    sources=["plugins/encoders/secplus_v2_encoder.c"],
+)

--- a/applications/main/subghz/helpers/subghz_txrx.c
+++ b/applications/main/subghz/helpers/subghz_txrx.c
@@ -1,5 +1,6 @@
 #include "subghz_txrx_i.h" // IWYU pragma: keep
 
+#include <lib/subghz/protocols/subghz_encoder_plugin_manager.h>
 #include <lib/subghz/protocols/protocol_items.h>
 #include <applications/drivers/subghz/cc1101_ext/cc1101_ext_interconnect.h>
 #include <lib/subghz/devices/cc1101_int/cc1101_int_interconnect.h>
@@ -65,6 +66,8 @@ SubGhzTxRx* subghz_txrx_alloc(void) {
     instance->radio_device_type =
         subghz_txrx_radio_device_set(instance, SubGhzRadioDeviceTypeExternalCC1101);
 
+    instance->encoder_plugin_manager = subghz_encoder_plugin_manager_alloc();
+
     return instance;
 }
 
@@ -84,6 +87,7 @@ void subghz_txrx_free(SubGhzTxRx* instance) {
     flipper_format_free(instance->fff_data);
     furi_string_free(instance->preset->name);
     subghz_setting_free(instance->setting);
+    subghz_encoder_plugin_manager_free(instance->encoder_plugin_manager);
 
     free(instance->preset);
     free(instance);
@@ -321,8 +325,28 @@ SubGhzTxRxStartTxState subghz_txrx_tx_start(SubGhzTxRx* instance, FlipperFormat*
         ret = SubGhzTxRxStartTxStateOk;
 
         SubGhzRadioPreset* preset = instance->preset;
-        instance->transmitter =
-            subghz_transmitter_alloc_init(instance->environment, furi_string_get_cstr(temp_str));
+        {
+            const char* _pname = furi_string_get_cstr(temp_str);
+            const SubGhzProtocol* _proto = subghz_protocol_registry_get_by_name(
+                subghz_environment_get_protocol_registry(instance->environment), _pname);
+            if(_proto && !_proto->encoder) {
+                if(!subghz_encoder_plugin_manager_is_loaded(instance->encoder_plugin_manager)) {
+                    subghz_encoder_plugin_manager_load(instance->encoder_plugin_manager, _pname);
+                }
+                if(subghz_encoder_plugin_manager_is_loaded(instance->encoder_plugin_manager)) {
+                    instance->transmitter = subghz_transmitter_alloc_init_with_encoder(
+                        instance->environment,
+                        _pname,
+                        (const SubGhzProtocolEncoder*)subghz_encoder_plugin_manager_get(
+                            instance->encoder_plugin_manager));
+                } else {
+                    instance->transmitter = NULL;
+                }
+            } else {
+                instance->transmitter =
+                    subghz_transmitter_alloc_init(instance->environment, _pname);
+            }
+        }
 
         if(instance->transmitter) {
             if(subghz_transmitter_deserialize(instance->transmitter, flipper_format) ==
@@ -607,12 +631,13 @@ bool subghz_txrx_protocol_is_serializable(SubGhzTxRx* instance) {
 bool subghz_txrx_protocol_is_transmittable(SubGhzTxRx* instance, bool check_type) {
     furi_assert(instance);
     const SubGhzProtocol* protocol = instance->decoder_result->protocol;
+    bool has_encoder = protocol->encoder != NULL ||
+                       subghz_encoder_plugin_manager_is_loaded(instance->encoder_plugin_manager);
     if(check_type) {
         return ((protocol->flag & SubGhzProtocolFlag_Send) == SubGhzProtocolFlag_Send) &&
-               protocol->encoder->deserialize && protocol->type == SubGhzProtocolTypeStatic;
+               has_encoder && protocol->type == SubGhzProtocolTypeStatic;
     }
-    return ((protocol->flag & SubGhzProtocolFlag_Send) == SubGhzProtocolFlag_Send) &&
-           protocol->encoder->deserialize;
+    return ((protocol->flag & SubGhzProtocolFlag_Send) == SubGhzProtocolFlag_Send) && has_encoder;
 }
 
 void subghz_txrx_receiver_set_filter(SubGhzTxRx* instance, SubGhzProtocolFlag filter) {

--- a/applications/main/subghz/helpers/subghz_txrx_create_protocol_key.c
+++ b/applications/main/subghz/helpers/subghz_txrx_create_protocol_key.c
@@ -495,18 +495,17 @@ bool subghz_txrx_gen_secplus_v2_protocol(
     furi_assert(instance);
 
     bool ret = false;
-    instance->transmitter =
-        subghz_transmitter_alloc_init(instance->environment, SUBGHZ_PROTOCOL_SECPLUS_V2_NAME);
     subghz_txrx_set_preset(instance, name_preset, frequency, NAN, NAN, NULL, 0);
-    if(instance->transmitter) {
-        subghz_protocol_secplus_v2_create_data(
-            subghz_transmitter_get_protocol_instance(instance->transmitter),
-            instance->fff_data,
-            serial,
-            btn,
-            cnt,
-            instance->preset);
-        ret = true;
+    subghz_encoder_plugin_manager_load(
+        instance->encoder_plugin_manager, SUBGHZ_PROTOCOL_SECPLUS_V2_NAME);
+    const SubGhzEncoderPlugin* plugin =
+        subghz_encoder_plugin_manager_get(instance->encoder_plugin_manager);
+    if(plugin && plugin->create_data) {
+        void* ctx = plugin->alloc(instance->environment);
+        if(ctx) {
+            ret = plugin->create_data(ctx, instance->fff_data, serial, btn, cnt, instance->preset);
+            plugin->free(ctx);
+        }
     }
     return ret;
 }

--- a/applications/main/subghz/helpers/subghz_txrx_i.h
+++ b/applications/main/subghz/helpers/subghz_txrx_i.h
@@ -1,6 +1,7 @@
-#pragma once
+﻿#pragma once
 
 #include "subghz_txrx.h"
+#include <subghz/protocols/subghz_encoder_plugin_manager.h>
 
 struct SubGhzTxRx {
     SubGhzWorker* worker;
@@ -20,6 +21,7 @@ struct SubGhzTxRx {
     SubGhzHopperState hopper_state;
 
     SubGhzTxRxState txrx_state;
+    SubGhzEncoderPluginManager* encoder_plugin_manager;
     SubGhzSpeakerState speaker_state;
     const SubGhzDevice* radio_device;
     SubGhzRadioDeviceType radio_device_type;

--- a/applications/main/subghz/plugins/encoders/secplus_v2_encoder.c
+++ b/applications/main/subghz/plugins/encoders/secplus_v2_encoder.c
@@ -1,0 +1,468 @@
+/**
+ * @file secplus_v2_encoder.c
+ * @brief Security+ 2.0 SubGHz encoder — SD-card plugin FAL.
+ *
+ * Compiled as FlipperAppType.PLUGIN and deployed to:
+ *   /ext/apps_data/subghz/plugins/subghz_encoder_secplus_v2.fal
+ *
+ * Self-contained: encode-path helpers are included directly so the main
+ * firmware only needs to link the decoder half of secplus_v2.c.
+ */
+
+#include <flipper_application/flipper_application.h>
+#include <lib/subghz/protocols/subghz_encoder_plugin.h>
+#include <lib/subghz/protocols/base.h>
+#include <lib/subghz/blocks/const.h>
+#include <lib/subghz/blocks/encoder.h>
+#include <lib/subghz/blocks/generic.h>
+#include <lib/subghz/blocks/math.h>
+#include <lib/subghz/blocks/custom_btn_i.h>
+#include <lib/toolbox/manchester_encoder.h>
+#include <furi.h>
+#include <furi_hal.h>
+
+#define TAG "SecPlusV2Enc"
+
+#define SECPLUS_V2_HEADER   0x3C0000000000ULL
+#define SECPLUS_V2_PACKET_1 0x000000000000ULL
+#define SECPLUS_V2_PACKET_2 0x010000000000ULL
+
+static const SubGhzBlockConst sp2_const = {
+    .te_short = 250,
+    .te_long = 500,
+    .te_delta = 110,
+    .min_count_bit_for_found = 62,
+};
+
+typedef struct {
+    SubGhzProtocolEncoderBase base;
+    SubGhzProtocolBlockEncoder encoder;
+    SubGhzBlockGeneric generic;
+    uint64_t secplus_packet_1;
+} SP2Ctx;
+
+static bool sp2_mix_invert(uint8_t inv, uint16_t p[]) {
+    switch(inv) {
+    case 0x00:
+        p[0] = ~p[0] & 0x3FF;
+        p[1] = ~p[1] & 0x3FF;
+        break;
+    case 0x01:
+        p[1] = ~p[1] & 0x3FF;
+        break;
+    case 0x02:
+        p[2] = ~p[2] & 0x3FF;
+        break;
+    case 0x04:
+        p[0] = ~p[0] & 0x3FF;
+        p[1] = ~p[1] & 0x3FF;
+        p[2] = ~p[2] & 0x3FF;
+        break;
+    case 0x05:
+    case 0x0a:
+        p[0] = ~p[0] & 0x3FF;
+        p[2] = ~p[2] & 0x3FF;
+        break;
+    case 0x06:
+        p[1] = ~p[1] & 0x3FF;
+        p[2] = ~p[2] & 0x3FF;
+        break;
+    case 0x08:
+        p[0] = ~p[0] & 0x3FF;
+        break;
+    case 0x09:
+        break;
+    default:
+        FURI_LOG_E(TAG, "Invert FAIL");
+        return false;
+    }
+    return true;
+}
+
+static bool sp2_order_decode(uint8_t ord, uint16_t p[]) {
+    uint16_t a = p[0], b = p[1], c = p[2];
+    switch(ord) {
+    case 0x06:
+    case 0x09:
+        p[2] = a;
+        p[0] = c;
+        break;
+    case 0x08:
+    case 0x04:
+        p[1] = a;
+        p[2] = b;
+        p[0] = c;
+        break;
+    case 0x01:
+        p[2] = a;
+        p[0] = b;
+        p[1] = c;
+        break;
+    case 0x00:
+        p[2] = b;
+        p[1] = c;
+        break;
+    case 0x05:
+        p[1] = a;
+        p[0] = b;
+        break;
+    case 0x02:
+    case 0x0A:
+        break;
+    default:
+        FURI_LOG_E(TAG, "Order FAIL");
+        return false;
+    }
+    return true;
+}
+
+static bool sp2_order_encode(uint8_t ord, uint16_t p[]) {
+    uint16_t a, b, c;
+    switch(ord) {
+    case 0x06:
+    case 0x09:
+        a = p[2];
+        b = p[1];
+        c = p[0];
+        break;
+    case 0x08:
+    case 0x04:
+        a = p[1];
+        b = p[2];
+        c = p[0];
+        break;
+    case 0x01:
+        a = p[2];
+        b = p[0];
+        c = p[1];
+        break;
+    case 0x00:
+        a = p[0];
+        b = p[2];
+        c = p[1];
+        break;
+    case 0x05:
+        a = p[1];
+        b = p[0];
+        c = p[2];
+        break;
+    case 0x02:
+    case 0x0A:
+        a = p[0];
+        b = p[1];
+        c = p[2];
+        break;
+    default:
+        FURI_LOG_E(TAG, "Order FAIL");
+        return false;
+    }
+    p[0] = a;
+    p[1] = b;
+    p[2] = c;
+    return true;
+}
+
+static bool sp2_decode_half(uint64_t data, uint8_t roll[], uint32_t* fixed) {
+    uint8_t ord = (data >> 34) & 0x0f, inv = (data >> 30) & 0x0f;
+    uint16_t p[3] = {0};
+    for(int i = 29; i >= 0; i -= 3) {
+        p[0] = p[0] << 1 | bit_read(data, i);
+        p[1] = p[1] << 1 | bit_read(data, i - 1);
+        p[2] = p[2] << 1 | bit_read(data, i - 2);
+    }
+    if(!sp2_mix_invert(inv, p) || !sp2_order_decode(ord, p)) return false;
+    data = ord << 4 | inv;
+    int k = 0;
+    for(int i = 6; i >= 0; i -= 2) {
+        roll[k] = (data >> i) & 3;
+        if(roll[k++] == 3) return false;
+    }
+    for(int i = 8; i >= 0; i -= 2) {
+        roll[k] = (p[2] >> i) & 3;
+        if(roll[k++] == 3) return false;
+    }
+    fixed[0] = p[0] << 10 | p[1];
+    return true;
+}
+
+static uint64_t sp2_encode_half(uint8_t roll[], uint32_t fixed) {
+    uint64_t data = 0;
+    uint16_t p[3] = {(fixed >> 10) & 0x3FF, fixed & 0x3FF, 0};
+    uint8_t ord = roll[0] << 2 | roll[1], inv = roll[2] << 2 | roll[3];
+    p[2] = (uint16_t)roll[4] << 8 | roll[5] << 6 | roll[6] << 4 | roll[7] << 2 | roll[8];
+    if(!sp2_order_encode(ord, p) || !sp2_mix_invert(inv, p)) return 0;
+    for(int i = 0; i < 10; i++) {
+        data <<= 3;
+        data |= bit_read(p[0], 9 - i) << 2 | bit_read(p[1], 9 - i) << 1 | bit_read(p[2], 9 - i);
+    }
+    data |= ((uint64_t)ord) << 34 | ((uint64_t)inv) << 30;
+    return data;
+}
+
+static void sp2_remote_controller(SubGhzBlockGeneric* g, uint64_t pkt1) {
+    uint32_t f1[1], f2[1];
+    uint8_t r1[9] = {0}, r2[9] = {0}, d[18] = {0};
+    if(sp2_decode_half(pkt1, r1, f1) && sp2_decode_half(g->data, r2, f2)) {
+        d[0] = r2[8];
+        d[1] = r1[8];
+        d[2] = r2[4];
+        d[3] = r2[5];
+        d[4] = r2[6];
+        d[5] = r2[7];
+        d[6] = r1[4];
+        d[7] = r1[5];
+        d[8] = r1[6];
+        d[9] = r1[7];
+        d[10] = r2[0];
+        d[11] = r2[1];
+        d[12] = r2[2];
+        d[13] = r2[3];
+        d[14] = r1[0];
+        d[15] = r1[1];
+        d[16] = r1[2];
+        d[17] = r1[3];
+        uint32_t rolling = 0;
+        for(int i = 0; i < 18; i++)
+            rolling = (rolling * 3) + d[i];
+        if(rolling >= 0x10000000) {
+            g->cnt = 0;
+            g->btn = 0;
+            g->serial = 0;
+        } else {
+            g->cnt = subghz_protocol_blocks_reverse_key(rolling, 28);
+            g->btn = f1[0] >> 12;
+            g->serial = f1[0] << 20 | f2[0];
+        }
+    } else {
+        g->cnt = 0;
+        g->btn = 0;
+        g->serial = 0;
+    }
+}
+
+static uint8_t sp2_get_btn(void) {
+    uint8_t id = subghz_custom_btn_get(), orig = subghz_custom_btn_get_original(), btn = orig;
+    if(id == SUBGHZ_CUSTOM_BTN_OK && orig) return orig;
+    if(id == SUBGHZ_CUSTOM_BTN_UP) {
+        switch(orig) {
+        case 0x68:
+            return 0x80;
+        case 0x80:
+            return 0x68;
+        default:
+            return 0x80;
+        }
+    }
+    if(id == SUBGHZ_CUSTOM_BTN_DOWN) {
+        switch(orig) {
+        case 0x81:
+            return 0x68;
+        default:
+            return 0x81;
+        }
+    }
+    if(id == SUBGHZ_CUSTOM_BTN_LEFT) {
+        switch(orig) {
+        case 0xE2:
+            return 0x68;
+        default:
+            return 0xE2;
+        }
+    }
+    if(id == SUBGHZ_CUSTOM_BTN_RIGHT) {
+        switch(orig) {
+        case 0x78:
+            return 0x68;
+        default:
+            return 0x78;
+        }
+    }
+    return btn;
+}
+
+static void sp2_encode(SP2Ctx* ctx) {
+    ctx->generic.btn = sp2_get_btn();
+    if(subghz_block_generic_global_button_override_get(&ctx->generic.btn))
+        FURI_LOG_D(TAG, "Button->0x%X", ctx->generic.btn);
+    uint32_t f1[1] = {ctx->generic.btn << 12 | ctx->generic.serial >> 20};
+    uint32_t f2[1] = {ctx->generic.serial & 0xFFFFF};
+    uint8_t d[18] = {0}, r1[9] = {0}, r2[9] = {0};
+    if(furi_hal_subghz_get_rolling_counter_mult() != -0x7FFFFFFF) {
+        if(!subghz_block_generic_global_counter_override_get(&ctx->generic.cnt)) {
+            if((ctx->generic.cnt + furi_hal_subghz_get_rolling_counter_mult()) > 0xFFFFFFF)
+                ctx->generic.cnt = 0xE500000;
+            else
+                ctx->generic.cnt += furi_hal_subghz_get_rolling_counter_mult();
+        }
+        if(ctx->generic.cnt < 0xE500000) ctx->generic.cnt = 0xE500000;
+    } else {
+        if((ctx->generic.cnt + 1) > 0xFFFFFFF)
+            ctx->generic.cnt = 0xE500000;
+        else if(ctx->generic.cnt >= 0xE500000 && ctx->generic.cnt != 0xFFFFFFE)
+            ctx->generic.cnt = 0xFFFFFFE;
+        else
+            ctx->generic.cnt++;
+    }
+    uint32_t rolling = subghz_protocol_blocks_reverse_key(ctx->generic.cnt, 28);
+    for(int8_t i = 17; i > -1; i--) {
+        d[i] = rolling % 3;
+        rolling /= 3;
+    }
+    r2[8] = d[0];
+    r1[8] = d[1];
+    r2[4] = d[2];
+    r2[5] = d[3];
+    r2[6] = d[4];
+    r2[7] = d[5];
+    r1[4] = d[6];
+    r1[5] = d[7];
+    r1[6] = d[8];
+    r1[7] = d[9];
+    r2[0] = d[10];
+    r2[1] = d[11];
+    r2[2] = d[12];
+    r2[3] = d[13];
+    r1[0] = d[14];
+    r1[1] = d[15];
+    r1[2] = d[16];
+    r1[3] = d[17];
+    ctx->secplus_packet_1 = SECPLUS_V2_HEADER | SECPLUS_V2_PACKET_1 | sp2_encode_half(r1, f1[0]);
+    ctx->generic.data = SECPLUS_V2_HEADER | SECPLUS_V2_PACKET_2 | sp2_encode_half(r2, f2[0]);
+}
+
+static LevelDuration sp2_ld(ManchesterEncoderResult r) {
+    switch(r) {
+    case ManchesterEncoderResultShortLow:
+        return level_duration_make(false, sp2_const.te_short);
+    case ManchesterEncoderResultLongLow:
+        return level_duration_make(false, sp2_const.te_long);
+    case ManchesterEncoderResultLongHigh:
+        return level_duration_make(true, sp2_const.te_long);
+    case ManchesterEncoderResultShortHigh:
+        return level_duration_make(true, sp2_const.te_short);
+    default:
+        furi_crash("SubGhz: Manchester result incorrect.");
+        return level_duration_reset();
+    }
+}
+
+static void sp2_get_upload(SP2Ctx* ctx) {
+    size_t idx = 0;
+    ManchesterEncoderState st;
+    ManchesterEncoderResult r;
+    manchester_encoder_reset(&st);
+    for(uint8_t i = ctx->generic.data_count_bit; i > 0; i--) {
+        if(!manchester_encoder_advance(&st, bit_read(ctx->secplus_packet_1, i - 1), &r)) {
+            ctx->encoder.upload[idx++] = sp2_ld(r);
+            manchester_encoder_advance(&st, bit_read(ctx->secplus_packet_1, i - 1), &r);
+        }
+        ctx->encoder.upload[idx++] = sp2_ld(r);
+    }
+    ctx->encoder.upload[idx] = sp2_ld(manchester_encoder_finish(&st));
+    if(level_duration_get_level(ctx->encoder.upload[idx])) idx++;
+    ctx->encoder.upload[idx++] = level_duration_make(false, (uint32_t)sp2_const.te_long * 136);
+    manchester_encoder_reset(&st);
+    for(uint8_t i = ctx->generic.data_count_bit; i > 0; i--) {
+        if(!manchester_encoder_advance(&st, bit_read(ctx->generic.data, i - 1), &r)) {
+            ctx->encoder.upload[idx++] = sp2_ld(r);
+            manchester_encoder_advance(&st, bit_read(ctx->generic.data, i - 1), &r);
+        }
+        ctx->encoder.upload[idx++] = sp2_ld(r);
+    }
+    ctx->encoder.upload[idx] = sp2_ld(manchester_encoder_finish(&st));
+    if(level_duration_get_level(ctx->encoder.upload[idx])) idx++;
+    ctx->encoder.upload[idx++] = level_duration_make(false, (uint32_t)sp2_const.te_long * 136);
+    ctx->encoder.size_upload = idx;
+}
+
+static SubGhzProtocolEncoderBase* sp2_alloc(SubGhzEnvironment* env) {
+    UNUSED(env);
+    SP2Ctx* ctx = malloc(sizeof(SP2Ctx));
+    ctx->base.protocol = NULL;
+    ctx->generic.protocol_name = "Security+ 2.0";
+    ctx->encoder.repeat = 3;
+    ctx->encoder.size_upload = 256;
+    ctx->encoder.upload = malloc(ctx->encoder.size_upload * sizeof(LevelDuration));
+    ctx->encoder.is_running = false;
+    return (SubGhzProtocolEncoderBase*)ctx;
+}
+
+static void sp2_free(void* ctx_) {
+    SP2Ctx* ctx = ctx_;
+    free(ctx->encoder.upload);
+    free(ctx);
+}
+
+static SubGhzProtocolStatus sp2_deserialize(void* ctx_, FlipperFormat* ff) {
+    SP2Ctx* ctx = ctx_;
+    SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
+    do {
+        ret = subghz_block_generic_deserialize_check_count_bit(
+            &ctx->generic, ff, sp2_const.min_count_bit_for_found);
+        if(ret != SubGhzProtocolStatusOk) break;
+        uint8_t kd[sizeof(uint64_t)] = {0};
+        if(!flipper_format_read_hex(ff, "Secplus_packet_1", kd, sizeof(uint64_t))) {
+            ret = SubGhzProtocolStatusErrorParserOthers;
+            break;
+        }
+        for(uint8_t i = 0; i < sizeof(uint64_t); i++)
+            ctx->secplus_packet_1 = ctx->secplus_packet_1 << 8 | kd[i];
+        sp2_remote_controller(&ctx->generic, ctx->secplus_packet_1);
+        sp2_encode(ctx);
+        flipper_format_read_uint32(ff, "Repeat", (uint32_t*)&ctx->encoder.repeat, 1);
+        sp2_get_upload(ctx);
+        for(size_t i = 0; i < sizeof(uint64_t); i++)
+            kd[sizeof(uint64_t) - i - 1] = (ctx->generic.data >> (i * 8)) & 0xFF;
+        if(!flipper_format_update_hex(ff, "Key", kd, sizeof(uint64_t))) {
+            ret = SubGhzProtocolStatusErrorParserKey;
+            break;
+        }
+        for(size_t i = 0; i < sizeof(uint64_t); i++)
+            kd[sizeof(uint64_t) - i - 1] = (ctx->secplus_packet_1 >> (i * 8)) & 0xFF;
+        if(!flipper_format_update_hex(ff, "Secplus_packet_1", kd, sizeof(uint64_t))) {
+            ret = SubGhzProtocolStatusErrorParserOthers;
+            break;
+        }
+        ctx->encoder.front = 0;
+        ctx->encoder.is_running = true;
+    } while(false);
+    return ret;
+}
+
+static void sp2_stop(void* ctx_) {
+    SP2Ctx* ctx = ctx_;
+    ctx->encoder.is_running = false;
+    ctx->encoder.front = 0;
+}
+
+static LevelDuration sp2_yield(void* ctx_) {
+    SP2Ctx* ctx = ctx_;
+    if(ctx->encoder.repeat == 0 || !ctx->encoder.is_running) {
+        ctx->encoder.is_running = false;
+        return level_duration_reset();
+    }
+    LevelDuration ret = ctx->encoder.upload[ctx->encoder.front];
+    if(++ctx->encoder.front == ctx->encoder.size_upload) {
+        if(!subghz_block_generic_global.endless_tx) ctx->encoder.repeat--;
+        ctx->encoder.front = 0;
+    }
+    return ret;
+}
+
+static const SubGhzEncoderPlugin sp2_plugin = {
+    .alloc = sp2_alloc,
+    .free = sp2_free,
+    .deserialize = sp2_deserialize,
+    .stop = sp2_stop,
+    .yield = sp2_yield,
+};
+
+static const FlipperAppPluginDescriptor sp2_descriptor = {
+    .appid = SUBGHZ_ENCODER_PLUGIN_APP_ID,
+    .ep_api_version = SUBGHZ_ENCODER_PLUGIN_API_VERSION,
+    .entry_point = &sp2_plugin,
+};
+
+const FlipperAppPluginDescriptor* secplus_v2_encoder_plugin_ep(void) {
+    return &sp2_descriptor;
+}

--- a/applications/main/subghz/plugins/encoders/secplus_v2_encoder.c
+++ b/applications/main/subghz/plugins/encoders/secplus_v2_encoder.c
@@ -449,12 +449,33 @@ static LevelDuration sp2_yield(void* ctx_) {
     return ret;
 }
 
+static bool sp2_create_data(
+    void* ctx_,
+    FlipperFormat* ff,
+    uint32_t serial,
+    uint8_t btn,
+    uint32_t cnt,
+    SubGhzRadioPreset* preset) {
+    SP2Ctx* ctx = ctx_;
+    ctx->generic.serial = serial;
+    ctx->generic.btn = btn;
+    ctx->generic.cnt = cnt;
+    ctx->generic.data_count_bit = sp2_const.min_count_bit_for_found;
+    sp2_encode(ctx);
+    if(subghz_block_generic_serialize(&ctx->generic, ff, preset) != SubGhzProtocolStatusOk)
+        return false;
+    uint8_t kd[sizeof(uint64_t)] = {0};
+    for(size_t i = 0; i < sizeof(uint64_t); i++)
+        kd[sizeof(uint64_t) - i - 1] = (ctx->secplus_packet_1 >> (i * 8)) & 0xFF;
+    return flipper_format_write_hex(ff, "Secplus_packet_1", kd, sizeof(uint64_t));
+}
 static const SubGhzEncoderPlugin sp2_plugin = {
     .alloc = sp2_alloc,
     .free = sp2_free,
     .deserialize = sp2_deserialize,
     .stop = sp2_stop,
     .yield = sp2_yield,
+    .create_data = sp2_create_data,
 };
 
 static const FlipperAppPluginDescriptor sp2_descriptor = {

--- a/applications/main/subghz/scenes/subghz_scene_decode_raw.c
+++ b/applications/main/subghz/scenes/subghz_scene_decode_raw.c
@@ -1,4 +1,5 @@
 #include "../subghz_i.h"
+#include "../helpers/subghz_txrx_i.h"
 
 #define TAG "SubGhzDecodeRaw"
 
@@ -85,6 +86,11 @@ static void subghz_scene_add_to_history_callback(
     }
 
     if(subghz_history_add_to_history(subghz->history, decoder_base, &preset)) {
+        if(decoder_base->protocol && !decoder_base->protocol->encoder &&
+           subghz->txrx->encoder_plugin_manager) {
+            subghz_encoder_plugin_manager_load(
+                subghz->txrx->encoder_plugin_manager, decoder_base->protocol->name);
+        }
         furi_string_reset(item_name);
         furi_string_reset(item_time);
 

--- a/applications/main/subghz/scenes/subghz_scene_receiver.c
+++ b/applications/main/subghz/scenes/subghz_scene_receiver.c
@@ -1,4 +1,5 @@
 #include "../subghz_i.h"
+#include "../helpers/subghz_txrx_i.h"
 #include <dolphin/dolphin.h>
 #include <lib/subghz/protocols/bin_raw.h>
 #include <toolbox/name_generator.h>
@@ -161,6 +162,11 @@ static void subghz_scene_add_to_history_callback(
     }
 
     if(subghz_history_add_to_history(history, decoder_base, &preset)) {
+        if(decoder_base->protocol && !decoder_base->protocol->encoder &&
+           subghz->txrx->encoder_plugin_manager) {
+            subghz_encoder_plugin_manager_load(
+                subghz->txrx->encoder_plugin_manager, decoder_base->protocol->name);
+        }
         furi_string_reset(item_name);
         furi_string_reset(item_time);
 
@@ -267,6 +273,8 @@ void subghz_scene_receiver_on_enter(void* context) {
         subghz->tx_power = subghz->last_settings->tx_power;
 
         subghz_history_reset(history);
+        if(subghz->txrx->encoder_plugin_manager)
+            subghz_encoder_plugin_manager_unload(subghz->txrx->encoder_plugin_manager);
         subghz_rx_key_state_set(subghz, SubGhzRxKeyStateStart);
         subghz->idx_menu_chosen = 0;
     }

--- a/applications/main/subghz/scenes/subghz_scene_receiver_info.c
+++ b/applications/main/subghz/scenes/subghz_scene_receiver_info.c
@@ -130,6 +130,16 @@ void subghz_scene_receiver_info_on_enter(void* context) {
 
     subghz_custom_btns_reset();
 
+    const char* proto_name =
+        subghz_history_get_protocol_name(subghz->history, subghz->idx_menu_chosen);
+    if(proto_name && subghz->txrx->encoder_plugin_manager) {
+        const SubGhzProtocol* _ep = subghz_protocol_registry_get_by_name(
+            subghz_environment_get_protocol_registry(subghz->txrx->environment), proto_name);
+        if(_ep && !_ep->encoder) {
+            subghz_encoder_plugin_manager_load(subghz->txrx->encoder_plugin_manager, proto_name);
+        }
+    }
+
     subghz_scene_receiver_info_draw_widget(subghz);
 
     if(!subghz_history_full(subghz->history) &&

--- a/applications/main/subghz/scenes/subghz_scene_transmitter.c
+++ b/applications/main/subghz/scenes/subghz_scene_transmitter.c
@@ -61,6 +61,23 @@ void subghz_scene_transmitter_on_enter(void* context) {
 
     subghz_custom_btns_reset();
 
+    do {
+        FlipperFormat* fff = subghz_txrx_get_fff_data(subghz->txrx);
+        if(!fff) break;
+        FuriString* pname = furi_string_alloc();
+        if(!flipper_format_rewind(fff) || !flipper_format_read_string(fff, "Protocol", pname)) {
+            furi_string_free(pname);
+            break;
+        }
+        const SubGhzProtocol* _p = subghz_protocol_registry_get_by_name(
+            subghz_environment_get_protocol_registry(subghz->txrx->environment),
+            furi_string_get_cstr(pname));
+        if(_p && !_p->encoder && subghz->txrx->encoder_plugin_manager)
+            subghz_encoder_plugin_manager_load(
+                subghz->txrx->encoder_plugin_manager, furi_string_get_cstr(pname));
+        furi_string_free(pname);
+    } while(false);
+
     if(!subghz_scene_transmitter_update_data_show(subghz)) {
         view_dispatcher_send_custom_event(
             subghz->view_dispatcher, SubGhzCustomEventViewTransmitterError);

--- a/lib/subghz/protocols/secplus_v2.c
+++ b/lib/subghz/protocols/secplus_v2.c
@@ -68,6 +68,7 @@ const SubGhzProtocolDecoder subghz_protocol_secplus_v2_decoder = {
     .get_string_brief = NULL,
 };
 
+#ifndef SUBGHZ_SECPLUS_V2_ENCODER_IN_FLASH
 const SubGhzProtocolEncoder subghz_protocol_secplus_v2_encoder = {
     .alloc = subghz_protocol_encoder_secplus_v2_alloc,
     .free = subghz_protocol_encoder_secplus_v2_free,
@@ -77,6 +78,8 @@ const SubGhzProtocolEncoder subghz_protocol_secplus_v2_encoder = {
     .yield = subghz_protocol_encoder_secplus_v2_yield,
 };
 
+#endif
+
 const SubGhzProtocol subghz_protocol_secplus_v2 = {
     .name = SUBGHZ_PROTOCOL_SECPLUS_V2_NAME,
     .type = SubGhzProtocolTypeDynamic,
@@ -84,9 +87,10 @@ const SubGhzProtocol subghz_protocol_secplus_v2 = {
             SubGhzProtocolFlag_Load | SubGhzProtocolFlag_Save | SubGhzProtocolFlag_Send,
 
     .decoder = &subghz_protocol_secplus_v2_decoder,
-    .encoder = &subghz_protocol_secplus_v2_encoder,
+    .encoder = NULL,
 };
 
+#ifndef SUBGHZ_SECPLUS_V2_ENCODER_IN_FLASH
 void* subghz_protocol_encoder_secplus_v2_alloc(SubGhzEnvironment* environment) {
     UNUSED(environment);
     SubGhzProtocolEncoderSecPlus_v2* instance = malloc(sizeof(SubGhzProtocolEncoderSecPlus_v2));
@@ -636,6 +640,8 @@ LevelDuration subghz_protocol_encoder_secplus_v2_yield(void* context) {
     return ret;
 }
 
+#endif
+
 bool subghz_protocol_secplus_v2_create_data(
     void* context,
     FlipperFormat* flipper_format,
@@ -644,28 +650,12 @@ bool subghz_protocol_secplus_v2_create_data(
     uint32_t cnt,
     SubGhzRadioPreset* preset) {
     furi_check(context);
-
-    SubGhzProtocolEncoderSecPlus_v2* instance = context;
-    instance->generic.serial = serial;
-    instance->generic.cnt = cnt;
-    instance->generic.btn = btn;
-    instance->generic.data_count_bit =
-        (uint8_t)subghz_protocol_secplus_v2_const.min_count_bit_for_found;
-    subghz_protocol_secplus_v2_encode(instance);
-    SubGhzProtocolStatus res =
-        subghz_block_generic_serialize(&instance->generic, flipper_format, preset);
-
-    uint8_t key_data[sizeof(uint64_t)] = {0};
-    for(size_t i = 0; i < sizeof(uint64_t); i++) {
-        key_data[sizeof(uint64_t) - i - 1] = (instance->secplus_packet_1 >> (i * 8)) & 0xFF;
-    }
-
-    if((res == SubGhzProtocolStatusOk) &&
-       !flipper_format_write_hex(flipper_format, "Secplus_packet_1", key_data, sizeof(uint64_t))) {
-        FURI_LOG_E(TAG, "Unable to add Secplus_packet_1");
-        res = SubGhzProtocolStatusErrorParserOthers;
-    }
-    return res == SubGhzProtocolStatusOk;
+    UNUSED(flipper_format);
+    UNUSED(serial);
+    UNUSED(btn);
+    UNUSED(cnt);
+    UNUSED(preset);
+    return false;
 }
 
 void* subghz_protocol_decoder_secplus_v2_alloc(SubGhzEnvironment* environment) {

--- a/lib/subghz/protocols/subghz_encoder_plugin.h
+++ b/lib/subghz/protocols/subghz_encoder_plugin.h
@@ -1,0 +1,38 @@
+﻿#pragma once
+
+#include "base.h"
+#include <flipper_format/flipper_format.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file subghz_encoder_plugin.h
+ * @brief SubGHz encoder plugin interface for SD-card dynamic loading.
+ *
+ * Each encodable SubGHz protocol ships its encoder as a PLUGIN FAL at:
+ *   /ext/apps_data/subghz/plugins/<Protocol Name>.fal
+ *
+ * The FAL entry_point function returns a FlipperAppPluginDescriptor whose
+ * entry_point field points to a SubGhzEncoderPlugin vtable.
+ *
+ * IMPORTANT: yield() is called from a hardware timer ISR.
+ * The FAL is mapped to RAM by plugin_manager so all function pointers are
+ * safe to call from ISR context. No blocking, no heap alloc inside yield().
+ */
+
+#define SUBGHZ_ENCODER_PLUGIN_APP_ID      "SubGhzEncoderPlugin"
+#define SUBGHZ_ENCODER_PLUGIN_API_VERSION 1
+
+typedef struct {
+    SubGhzProtocolEncoderBase* (*alloc)(SubGhzEnvironment* environment);
+    void (*free)(void* context);
+    SubGhzProtocolStatus (*deserialize)(void* context, FlipperFormat* flipper_format);
+    void (*stop)(void* context);
+    LevelDuration (*yield)(void* context);
+} SubGhzEncoderPlugin;
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/subghz/protocols/subghz_encoder_plugin.h
+++ b/lib/subghz/protocols/subghz_encoder_plugin.h
@@ -31,6 +31,7 @@ typedef struct {
     SubGhzProtocolStatus (*deserialize)(void* context, FlipperFormat* flipper_format);
     void (*stop)(void* context);
     LevelDuration (*yield)(void* context);
+    bool (*create_data)(void* context, FlipperFormat* flipper_format, uint32_t serial, uint8_t btn, uint32_t cnt, SubGhzRadioPreset* preset);
 } SubGhzEncoderPlugin;
 
 #ifdef __cplusplus

--- a/lib/subghz/protocols/subghz_encoder_plugin_manager.c
+++ b/lib/subghz/protocols/subghz_encoder_plugin_manager.c
@@ -1,0 +1,103 @@
+#include "subghz_encoder_plugin_manager.h"
+
+#include <lib/flipper_application/plugins/plugin_manager.h>
+#include <storage/storage.h>
+#include <furi.h>
+
+#define TAG "SubGhzEncMgr"
+
+struct SubGhzEncoderPluginManager {
+    PluginManager* pm;
+    const SubGhzEncoderPlugin* plugin;
+    char loaded_protocol[64];
+};
+
+SubGhzEncoderPluginManager* subghz_encoder_plugin_manager_alloc(void) {
+    SubGhzEncoderPluginManager* m = malloc(sizeof(SubGhzEncoderPluginManager));
+    furi_assert(m);
+    m->pm = NULL;
+    m->plugin = NULL;
+    m->loaded_protocol[0] = '\0';
+    return m;
+}
+
+void subghz_encoder_plugin_manager_free(SubGhzEncoderPluginManager* manager) {
+    furi_assert(manager);
+    subghz_encoder_plugin_manager_unload(manager);
+    free(manager);
+}
+bool subghz_encoder_plugin_manager_load(
+    SubGhzEncoderPluginManager* manager,
+    const char* protocol_name) {
+    furi_assert(manager);
+    furi_assert(protocol_name);
+
+    if(manager->pm && strncmp(manager->loaded_protocol, protocol_name, 63) == 0) {
+        FURI_LOG_D(TAG, "Cache hit '%s'", protocol_name);
+        return true;
+    }
+
+    subghz_encoder_plugin_manager_unload(manager);
+
+    Storage* storage = furi_record_open(RECORD_STORAGE);
+    FS_Error sd_status = storage_sd_status(storage);
+    furi_record_close(RECORD_STORAGE);
+    if(sd_status != FSE_OK) {
+        FURI_LOG_W(TAG, "SD not ready (status=%d), encoder load skipped", sd_status);
+        return false;
+    }
+
+    char path[128];
+    char fal_name[64];
+    if(strcmp(protocol_name, "Security+ 2.0") == 0) {
+        strncpy(fal_name, "subghz_encoder_secplus_v2", sizeof(fal_name) - 1);
+    } else {
+        strncpy(fal_name, protocol_name, sizeof(fal_name) - 1);
+    }
+    fal_name[sizeof(fal_name) - 1] = '\0';
+    snprintf(path, sizeof(path), "%s/%s.fal", SUBGHZ_ENCODER_FAL_DIR, fal_name);
+    FURI_LOG_I(TAG, "Loading %s", path);
+
+    manager->pm = plugin_manager_alloc(
+        SUBGHZ_ENCODER_PLUGIN_APP_ID, SUBGHZ_ENCODER_PLUGIN_API_VERSION, NULL);
+
+    PluginManagerError err = plugin_manager_load_single(manager->pm, path);
+    if(err != PluginManagerErrorNone) {
+        FURI_LOG_W(TAG, "Load failed err=%d path=%s", err, path);
+        plugin_manager_free(manager->pm);
+        manager->pm = NULL;
+        return false;
+    }
+
+    manager->plugin = (const SubGhzEncoderPlugin*)plugin_manager_get_ep(manager->pm, 0);
+    if(!manager->plugin) {
+        FURI_LOG_E(TAG, "No entry point in FAL for '%s'", protocol_name);
+        plugin_manager_free(manager->pm);
+        manager->pm = NULL;
+        return false;
+    }
+
+    strncpy(manager->loaded_protocol, protocol_name, 63);
+    manager->loaded_protocol[63] = '\0';
+    FURI_LOG_I(TAG, "Loaded encoder for '%s'", protocol_name);
+    return true;
+}
+
+void subghz_encoder_plugin_manager_unload(SubGhzEncoderPluginManager* manager) {
+    furi_assert(manager);
+    if(!manager->pm) return;
+    FURI_LOG_I(TAG, "Unloading encoder '%s'", manager->loaded_protocol);
+    plugin_manager_free(manager->pm);
+    manager->pm = NULL;
+    manager->plugin = NULL;
+    manager->loaded_protocol[0] = '\0';
+}
+
+const SubGhzEncoderPlugin* subghz_encoder_plugin_manager_get(SubGhzEncoderPluginManager* manager) {
+    if(!manager || !manager->pm) return NULL;
+    return manager->plugin;
+}
+
+bool subghz_encoder_plugin_manager_is_loaded(SubGhzEncoderPluginManager* manager) {
+    return manager && manager->pm;
+}

--- a/lib/subghz/protocols/subghz_encoder_plugin_manager.h
+++ b/lib/subghz/protocols/subghz_encoder_plugin_manager.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "subghz_encoder_plugin.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file subghz_encoder_plugin_manager.h
+ * @brief Manages loading/unloading a single SubGHz encoder FAL from SD card.
+ *
+ * Lifetime:
+ *   alloc   -> subghz_txrx_alloc()
+ *   load    -> subghz_scene_receiver_info_on_enter() (after decode)
+ *   unload  -> subghz_scene_receiver_info_on_exit()  (when result cleared)
+ *   free    -> subghz_txrx_free()
+ *
+ * Only one encoder lives in RAM at a time. Same-protocol loads are cache hits.
+ */
+
+#define SUBGHZ_ENCODER_FAL_DIR EXT_PATH("apps_data/subghz/plugins")
+
+typedef struct SubGhzEncoderPluginManager SubGhzEncoderPluginManager;
+
+SubGhzEncoderPluginManager* subghz_encoder_plugin_manager_alloc(void);
+void subghz_encoder_plugin_manager_free(SubGhzEncoderPluginManager* manager);
+
+bool subghz_encoder_plugin_manager_load(
+    SubGhzEncoderPluginManager* manager,
+    const char* protocol_name);
+
+void subghz_encoder_plugin_manager_unload(SubGhzEncoderPluginManager* manager);
+
+const SubGhzEncoderPlugin* subghz_encoder_plugin_manager_get(SubGhzEncoderPluginManager* manager);
+
+bool subghz_encoder_plugin_manager_is_loaded(SubGhzEncoderPluginManager* manager);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/subghz/transmitter.c
+++ b/lib/subghz/transmitter.c
@@ -6,7 +6,12 @@
 struct SubGhzTransmitter {
     const SubGhzProtocol* protocol;
     SubGhzProtocolEncoderBase* protocol_instance;
+    const SubGhzProtocolEncoder* encoder_override;
 };
+
+static inline const SubGhzProtocolEncoder* txr_get_enc(const SubGhzTransmitter* t) {
+    return t->encoder_override ? t->encoder_override : t->protocol->encoder;
+}
 
 SubGhzTransmitter*
     subghz_transmitter_alloc_init(SubGhzEnvironment* environment, const char* protocol_name) {
@@ -20,6 +25,7 @@ SubGhzTransmitter*
     if(protocol && protocol->encoder && protocol->encoder->alloc) {
         instance = malloc(sizeof(SubGhzTransmitter));
         instance->protocol = protocol;
+        instance->encoder_override = NULL;
         instance->protocol_instance = instance->protocol->encoder->alloc(environment);
     }
     return instance;
@@ -27,7 +33,7 @@ SubGhzTransmitter*
 
 void subghz_transmitter_free(SubGhzTransmitter* instance) {
     furi_check(instance);
-    instance->protocol->encoder->free(instance->protocol_instance);
+    txr_get_enc(instance)->free(instance->protocol_instance);
     free(instance);
 }
 
@@ -39,8 +45,9 @@ SubGhzProtocolEncoderBase* subghz_transmitter_get_protocol_instance(SubGhzTransm
 bool subghz_transmitter_stop(SubGhzTransmitter* instance) {
     furi_check(instance);
     bool ret = false;
-    if(instance->protocol && instance->protocol->encoder && instance->protocol->encoder->stop) {
-        instance->protocol->encoder->stop(instance->protocol_instance);
+    const SubGhzProtocolEncoder* enc = txr_get_enc(instance);
+    if(enc && enc->stop) {
+        enc->stop(instance->protocol_instance);
         ret = true;
     }
     return ret;
@@ -50,15 +57,32 @@ SubGhzProtocolStatus
     subghz_transmitter_deserialize(SubGhzTransmitter* instance, FlipperFormat* flipper_format) {
     furi_check(instance);
     SubGhzProtocolStatus ret = SubGhzProtocolStatusError;
-    if(instance->protocol && instance->protocol->encoder &&
-       instance->protocol->encoder->deserialize) {
-        ret =
-            instance->protocol->encoder->deserialize(instance->protocol_instance, flipper_format);
+    const SubGhzProtocolEncoder* enc = txr_get_enc(instance);
+    if(enc && enc->deserialize) {
+        ret = enc->deserialize(instance->protocol_instance, flipper_format);
     }
     return ret;
 }
 
 LevelDuration subghz_transmitter_yield(void* context) {
     SubGhzTransmitter* instance = context;
-    return instance->protocol->encoder->yield(instance->protocol_instance);
+    return txr_get_enc(instance)->yield(instance->protocol_instance);
+}
+
+SubGhzTransmitter* subghz_transmitter_alloc_init_with_encoder(
+    SubGhzEnvironment* environment,
+    const char* protocol_name,
+    const SubGhzProtocolEncoder* encoder_vtable) {
+    furi_assert(encoder_vtable);
+    furi_assert(encoder_vtable->alloc);
+
+    const SubGhzProtocolRegistry* registry = subghz_environment_get_protocol_registry(environment);
+    const SubGhzProtocol* protocol = subghz_protocol_registry_get_by_name(registry, protocol_name);
+    if(!protocol) return NULL;
+
+    SubGhzTransmitter* instance = malloc(sizeof(SubGhzTransmitter));
+    instance->protocol = protocol;
+    instance->encoder_override = encoder_vtable;
+    instance->protocol_instance = encoder_vtable->alloc(environment);
+    return instance;
 }

--- a/lib/subghz/transmitter.h
+++ b/lib/subghz/transmitter.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "types.h"
 #include "environment.h"
@@ -50,6 +50,11 @@ SubGhzProtocolStatus
  * @return LevelDuration 
  */
 LevelDuration subghz_transmitter_yield(void* context);
+
+SubGhzTransmitter* subghz_transmitter_alloc_init_with_encoder(
+    SubGhzEnvironment* environment,
+    const char* protocol_name,
+    const SubGhzProtocolEncoder* encoder_vtable);
 
 #ifdef __cplusplus
 }

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -3784,6 +3784,7 @@ Function,+,subghz_setting_load,void,"SubGhzSetting*, const char*"
 Function,+,subghz_setting_load_custom_preset,_Bool,"SubGhzSetting*, const char*, FlipperFormat*"
 Function,+,subghz_setting_set_default_frequency,void,"SubGhzSetting*, uint32_t"
 Function,+,subghz_transmitter_alloc_init,SubGhzTransmitter*,"SubGhzEnvironment*, const char*"
+Function,+,subghz_transmitter_alloc_init_with_encoder,SubGhzTransmitter*,"SubGhzEnvironment*, const char*, const SubGhzProtocolEncoder*"
 Function,+,subghz_transmitter_deserialize,SubGhzProtocolStatus,"SubGhzTransmitter*, FlipperFormat*"
 Function,+,subghz_transmitter_free,void,SubGhzTransmitter*
 Function,+,subghz_transmitter_get_protocol_instance,SubGhzProtocolEncoderBase*,SubGhzTransmitter*


### PR DESCRIPTION
# What's new

- Added lazy-loading support for SubGHz encoders
- Encoders can now be loaded from the SD card instead of being compiled directly into the firmware to save on flash size
- Currently only Security+ 2.0 has been finished and tested

# Overview

The goal is to help with the limited flash space by moving most of the encoder parts to the SD card and loading them dynamically when needed instead of keeping everything in flash. Currently this is more of a POC then a finished improvement there are many parts i could have done better and cut down on to save even more flash but i don't really have the time so i am just making this pr as a example of what could be done to help.

-----
# For the reviewer

- [X] I've uploaded the firmware with this patch to a device and verified its functionality
- [X] I've confirmed the bug to be fixed / feature to be stable
