### PR TITLE
fix(APP): loading perf changes

### DIFF
--- a/applications/main/momentum_app/momentum_app.c
+++ b/applications/main/momentum_app/momentum_app.c
@@ -210,7 +210,61 @@ void momentum_app_push_mainmenu_app(MomentumApp* app, FuriString* exe) {
     furi_string_free(label);
 }
 
+void momentum_app_load_asset_pack_names(MomentumApp* app) {
+    if(app->asset_pack_names_loaded) {
+        return;
+    }
+
+    app->asset_pack_index = 0;
+    File* folder = storage_file_alloc(app->storage);
+    FileInfo info;
+    char* name = malloc(ASSET_PACKS_NAME_LEN);
+    if(storage_dir_open(folder, ASSET_PACKS_PATH)) {
+        while(storage_dir_read(folder, &info, name, ASSET_PACKS_NAME_LEN)) {
+            if(info.flags & FSF_DIRECTORY && name[0] != '.') {
+                char* copy = strdup(name);
+                size_t idx = 0;
+                for(; idx < CharList_size(app->asset_pack_names); idx++) {
+                    char* comp = *CharList_get(app->asset_pack_names, idx);
+                    if(strcasecmp(copy, comp) < 0) {
+                        break;
+                    }
+                }
+                CharList_push_at(app->asset_pack_names, idx, copy);
+                if(app->asset_pack_index != 0) {
+                    if(idx < app->asset_pack_index) app->asset_pack_index++;
+                } else if(strcmp(copy, momentum_settings.asset_pack) == 0) {
+                    app->asset_pack_index = idx + 1;
+                }
+            }
+        }
+        storage_file_close(folder);
+    }
+    free(name);
+    storage_file_free(folder);
+
+    app->asset_pack_names_loaded = true;
+}
+
+void momentum_app_unload_asset_pack_names(MomentumApp* app) {
+    if(!app->asset_pack_names_loaded) {
+        return;
+    }
+
+    CharList_it_t it;
+    for(CharList_it(it, app->asset_pack_names); !CharList_end_p(it); CharList_next(it)) {
+        free(*CharList_cref(it));
+    }
+    CharList_reset(app->asset_pack_names);
+    app->asset_pack_index = 0;
+    app->asset_pack_names_loaded = false;
+}
+
 void momentum_app_load_mainmenu_apps(MomentumApp* app) {
+    if(app->mainmenu_apps_loaded) {
+        return;
+    }
+
     // Loading logic mimics applications/services/loader/loader_menu.c
     Stream* stream = file_stream_alloc(app->storage);
     FuriString* line = furi_string_alloc();
@@ -252,6 +306,7 @@ void momentum_app_load_mainmenu_apps(MomentumApp* app) {
     furi_string_free(line);
     file_stream_close(stream);
     stream_free(stream);
+    app->mainmenu_apps_loaded = true;
 }
 
 void momentum_app_empty_mainmenu_apps(MomentumApp* app) {
@@ -264,6 +319,16 @@ void momentum_app_empty_mainmenu_apps(MomentumApp* app) {
         free(*CharList_cref(it));
     }
     CharList_reset(app->mainmenu_app_exes);
+}
+
+void momentum_app_unload_mainmenu_apps(MomentumApp* app) {
+    if(!app->mainmenu_apps_loaded) {
+        return;
+    }
+
+    momentum_app_empty_mainmenu_apps(app);
+    app->mainmenu_app_index = 0;
+    app->mainmenu_apps_loaded = false;
 }
 
 MomentumApp* momentum_app_alloc() {
@@ -324,38 +389,14 @@ MomentumApp* momentum_app_alloc() {
 
     // Settings init
 
-    app->asset_pack_index = 0;
     CharList_init(app->asset_pack_names);
-    File* folder = storage_file_alloc(app->storage);
-    FileInfo info;
-    char* name = malloc(ASSET_PACKS_NAME_LEN);
-    if(storage_dir_open(folder, ASSET_PACKS_PATH)) {
-        while(storage_dir_read(folder, &info, name, ASSET_PACKS_NAME_LEN)) {
-            if(info.flags & FSF_DIRECTORY && name[0] != '.') {
-                char* copy = strdup(name);
-                size_t idx = 0;
-                for(; idx < CharList_size(app->asset_pack_names); idx++) {
-                    char* comp = *CharList_get(app->asset_pack_names, idx);
-                    if(strcasecmp(copy, comp) < 0) {
-                        break;
-                    }
-                }
-                CharList_push_at(app->asset_pack_names, idx, copy);
-                if(app->asset_pack_index != 0) {
-                    if(idx < app->asset_pack_index) app->asset_pack_index++;
-                } else {
-                    if(strcmp(copy, momentum_settings.asset_pack) == 0)
-                        app->asset_pack_index = idx + 1;
-                }
-            }
-        }
-    }
-    free(name);
-    storage_file_free(folder);
+    app->asset_pack_index = 0;
+    app->asset_pack_names_loaded = false;
 
     CharList_init(app->mainmenu_app_labels);
     CharList_init(app->mainmenu_app_exes);
-    momentum_app_load_mainmenu_apps(app);
+    app->mainmenu_app_index = 0;
+    app->mainmenu_apps_loaded = false;
 
     desktop_api_get_settings(app->desktop, &app->desktop_settings);
 
@@ -457,13 +498,10 @@ void momentum_app_free(MomentumApp* app) {
 
     // Settings deinit
 
-    CharList_it_t it;
-    for(CharList_it(it, app->asset_pack_names); !CharList_end_p(it); CharList_next(it)) {
-        free(*CharList_cref(it));
-    }
+    momentum_app_unload_asset_pack_names(app);
     CharList_clear(app->asset_pack_names);
 
-    momentum_app_empty_mainmenu_apps(app);
+    momentum_app_unload_mainmenu_apps(app);
     CharList_clear(app->mainmenu_app_labels);
     CharList_clear(app->mainmenu_app_exes);
 

--- a/applications/main/momentum_app/momentum_app.h
+++ b/applications/main/momentum_app/momentum_app.h
@@ -66,9 +66,11 @@ typedef struct {
 
     CharList_t asset_pack_names;
     uint8_t asset_pack_index;
+    bool asset_pack_names_loaded;
     CharList_t mainmenu_app_labels;
     CharList_t mainmenu_app_exes;
     uint8_t mainmenu_app_index;
+    bool mainmenu_apps_loaded;
     DesktopSettings desktop_settings;
     bool subghz_use_defaults;
     FrequencyList_t subghz_static_freqs;
@@ -109,8 +111,17 @@ typedef enum {
     MomentumAppViewDialogEx,
 } MomentumAppView;
 
+typedef enum {
+    MomentumAppMainmenuAddSourceMainApp,
+    MomentumAppMainmenuAddSourceExternalApp,
+    MomentumAppMainmenuAddSourceFileDirectory,
+} MomentumAppMainmenuAddSource;
+
 bool momentum_app_apply(MomentumApp* app);
 
 void momentum_app_push_mainmenu_app(MomentumApp* app, FuriString* exe);
+void momentum_app_load_asset_pack_names(MomentumApp* app);
+void momentum_app_unload_asset_pack_names(MomentumApp* app);
 void momentum_app_load_mainmenu_apps(MomentumApp* app);
 void momentum_app_empty_mainmenu_apps(MomentumApp* app);
+void momentum_app_unload_mainmenu_apps(MomentumApp* app);

--- a/applications/main/momentum_app/scenes/momentum_app_scene_interface_graphics.c
+++ b/applications/main/momentum_app/scenes/momentum_app_scene_interface_graphics.c
@@ -12,20 +12,6 @@ void momentum_app_scene_interface_graphics_var_item_list_callback(void* context,
     view_dispatcher_send_custom_event(app->view_dispatcher, index);
 }
 
-static void momentum_app_scene_interface_graphics_asset_pack_changed(VariableItem* item) {
-    MomentumApp* app = variable_item_get_context(item);
-    uint8_t index = variable_item_get_current_value_index(item);
-    variable_item_set_current_value_text(
-        item, index == 0 ? "Default" : *CharList_get(app->asset_pack_names, index - 1));
-    strlcpy(
-        momentum_settings.asset_pack,
-        index == 0 ? "" : *CharList_get(app->asset_pack_names, index - 1),
-        ASSET_PACKS_NAME_LEN);
-    app->asset_pack_index = index;
-    app->save_settings = true;
-    app->apply_pack = true;
-}
-
 const char* const anim_speed_names[] = {
     "25%",
     "50%",
@@ -121,15 +107,12 @@ void momentum_app_scene_interface_graphics_on_enter(void* context) {
     item = variable_item_list_add(
         var_item_list,
         "Asset Pack",
-        CharList_size(app->asset_pack_names) + 1,
-        momentum_app_scene_interface_graphics_asset_pack_changed,
+        0,
+        NULL,
         app);
-    variable_item_set_current_value_index(item, app->asset_pack_index);
     variable_item_set_current_value_text(
         item,
-        app->asset_pack_index == 0 ?
-            "Default" :
-            *CharList_get(app->asset_pack_names, app->asset_pack_index - 1));
+        momentum_settings.asset_pack[0] ? momentum_settings.asset_pack : "Default");
 
     item = variable_item_list_add(
         var_item_list,

--- a/applications/main/momentum_app/scenes/momentum_app_scene_interface_graphics_pack.c
+++ b/applications/main/momentum_app/scenes/momentum_app_scene_interface_graphics_pack.c
@@ -9,6 +9,8 @@ void momentum_app_scene_interface_graphics_pack_on_enter(void* context) {
     MomentumApp* app = context;
     Submenu* submenu = app->submenu;
 
+    momentum_app_load_asset_pack_names(app);
+
     submenu_add_item(
         submenu, "Default", 0, momentum_app_scene_interface_graphics_pack_submenu_callback, app);
 

--- a/applications/main/momentum_app/scenes/momentum_app_scene_interface_mainmenu.c
+++ b/applications/main/momentum_app/scenes/momentum_app_scene_interface_mainmenu.c
@@ -71,6 +71,8 @@ void momentum_app_scene_interface_mainmenu_on_enter(void* context) {
     VariableItemList* var_item_list = app->var_item_list;
     VariableItem* item;
 
+    momentum_app_load_mainmenu_apps(app);
+
     item = variable_item_list_add(
         var_item_list,
         "Menu Style",

--- a/applications/main/momentum_app/scenes/momentum_app_scene_interface_mainmenu_add.c
+++ b/applications/main/momentum_app/scenes/momentum_app_scene_interface_mainmenu_add.c
@@ -1,11 +1,5 @@
 #include "../momentum_app.h"
 
-enum SubmenuIndex {
-    SubmenuIndexMainApp,
-    SubmenuIndexExternalApp,
-    SubmenuIndexFileDirectory,
-};
-
 static bool fap_selector_item_callback(
     FuriString* file_path,
     void* context,
@@ -24,12 +18,14 @@ static void
     scene_manager_set_scene_state(app->scene_manager, MomentumAppSceneInterfaceMainmenuAdd, index);
 
     switch(index) {
-    case SubmenuIndexMainApp:
+    case MomentumAppMainmenuAddSourceMainApp:
         scene_manager_next_scene(app->scene_manager, MomentumAppSceneInterfaceMainmenuAddMain);
         break;
-    case SubmenuIndexExternalApp:
-    case SubmenuIndexFileDirectory: {
-        const bool is_file_dir = index == SubmenuIndexFileDirectory;
+    case MomentumAppMainmenuAddSourceExternalApp:
+        scene_manager_next_scene(app->scene_manager, MomentumAppSceneInterfaceMainmenuAddMain);
+        break;
+    case MomentumAppMainmenuAddSourceFileDirectory: {
+        const bool is_file_dir = true;
         const DialogsFileBrowserOptions browser_options = {
             .extension = is_file_dir ? "*" : ".fap",
             .icon = &I_unknown_10px,
@@ -66,21 +62,21 @@ void momentum_app_scene_interface_mainmenu_add_on_enter(void* context) {
     submenu_add_item(
         submenu,
         "Main App",
-        SubmenuIndexMainApp,
+        MomentumAppMainmenuAddSourceMainApp,
         momentum_app_scene_interface_mainmenu_add_submenu_callback,
         app);
 
     submenu_add_item(
         submenu,
         "External App",
-        SubmenuIndexExternalApp,
+        MomentumAppMainmenuAddSourceExternalApp,
         momentum_app_scene_interface_mainmenu_add_submenu_callback,
         app);
 
     submenu_add_item(
         submenu,
         "File / Directory (right btn)",
-        SubmenuIndexFileDirectory,
+        MomentumAppMainmenuAddSourceFileDirectory,
         momentum_app_scene_interface_mainmenu_add_submenu_callback,
         app);
 

--- a/applications/main/momentum_app/scenes/momentum_app_scene_interface_mainmenu_add_main.c
+++ b/applications/main/momentum_app/scenes/momentum_app_scene_interface_mainmenu_add_main.c
@@ -17,22 +17,29 @@ static void
 void momentum_app_scene_interface_mainmenu_add_main_on_enter(void* context) {
     MomentumApp* app = context;
     Submenu* submenu = app->submenu;
+    const uint32_t source =
+        scene_manager_get_scene_state(app->scene_manager, MomentumAppSceneInterfaceMainmenuAdd);
 
-    for(size_t i = 0; i < FLIPPER_APPS_COUNT; i++) {
-        submenu_add_item(
-            submenu,
-            FLIPPER_APPS[i].name,
-            (uint32_t)FLIPPER_APPS[i].name,
-            momentum_app_scene_interface_mainmenu_add_main_submenu_callback,
-            app);
-    }
-    for(size_t i = 0; i < FLIPPER_EXTERNAL_APPS_COUNT - 1; i++) {
-        submenu_add_item(
-            submenu,
-            FLIPPER_EXTERNAL_APPS[i].name,
-            (uint32_t)FLIPPER_EXTERNAL_APPS[i].name,
-            momentum_app_scene_interface_mainmenu_add_main_submenu_callback,
-            app);
+    if(source == MomentumAppMainmenuAddSourceMainApp) {
+        submenu_set_header(submenu, "Choose Main App:");
+        for(size_t i = 0; i < FLIPPER_APPS_COUNT; i++) {
+            submenu_add_item(
+                submenu,
+                FLIPPER_APPS[i].name,
+                (uint32_t)FLIPPER_APPS[i].name,
+                momentum_app_scene_interface_mainmenu_add_main_submenu_callback,
+                app);
+        }
+    } else {
+        submenu_set_header(submenu, "Choose External App:");
+        for(size_t i = 0; i < FLIPPER_EXTERNAL_APPS_COUNT - 1; i++) {
+            submenu_add_item(
+                submenu,
+                FLIPPER_EXTERNAL_APPS[i].name,
+                (uint32_t)FLIPPER_EXTERNAL_APPS[i].name,
+                momentum_app_scene_interface_mainmenu_add_main_submenu_callback,
+                app);
+        }
     }
 
     view_dispatcher_switch_to_view(app->view_dispatcher, MomentumAppViewSubmenu);


### PR DESCRIPTION
## Summary

This ports the `momentum_app` loading optimization without bringing in any localization changes.

## Changes

- lazy-load `mainmenu_app_labels` and `mainmenu_app_exes` only when entering the related scene
- lazy-load `asset_pack_names` only when entering the asset pack scene
- release both cached lists when no longer needed
- avoid building large VariableItemList/Submenu content until the corresponding subpage is actually opened
- keep UI strings unchanged from the target branch

## Why

Opening `momentum_app` was doing too much work up front:
- scanning asset packs during app alloc
- building menu app label/exe lists eagerly
- keeping large temporary lists alive longer than necessary

This reduces startup cost and lowers peak memory pressure when opening the app.

## Notes

This PR intentionally excludes CN/localization changes and only keeps the loading/perf behavior changes.
