### PR TITLE
fix vibro/RGB conflict and NTAG21x AUTH0 write block

### DIFF
--- a/lib/drivers/SK6805.c
+++ b/lib/drivers/SK6805.c
@@ -59,6 +59,7 @@ void SK6805_set_led_color(uint8_t led_index, uint8_t r, uint8_t g, uint8_t b) {
 
 void SK6805_update(void) {
     FURI_LOG_T(TAG, "update");
+    bool pin_was_high = furi_hal_gpio_read(SK6805_LED_PIN);
     SK6805_init();
     FURI_CRITICAL_ENTER();
     uint32_t end;
@@ -101,4 +102,5 @@ void SK6805_update(void) {
         }
     }
     FURI_CRITICAL_EXIT();
+    furi_hal_gpio_write(SK6805_LED_PIN, pin_was_high);
 }

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight.c
@@ -641,11 +641,15 @@ bool mf_ultralight_is_all_data_read(const MfUltralightData* data) {
             // so a default read on an auth-supported NTAG is never complete.
             MfUltralightConfigPages* config = NULL;
             if(mf_ultralight_get_config_page(data, &config)) {
-                uint32_t pass = bit_lib_bytes_to_num_be(
-                    config->password.data, sizeof(MfUltralightAuthPassword));
-                uint16_t pack =
-                    bit_lib_bytes_to_num_be(config->pack.data, sizeof(MfUltralightAuthPack));
-                all_read = ((pass != 0) || (pack != 0));
+                if(config->auth0 == 0xFF) {
+                    all_read = true;
+                } else {
+                    uint32_t pass = bit_lib_bytes_to_num_be(
+                        config->password.data, sizeof(MfUltralightAuthPassword));
+                    uint16_t pack =
+                        bit_lib_bytes_to_num_be(config->pack.data, sizeof(MfUltralightAuthPack));
+                    all_read = ((pass != 0) || (pack != 0));
+                }
             }
         }
     }

--- a/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller.c
+++ b/lib/nfc/protocols/mf_ultralight/mf_ultralight_poller.c
@@ -714,7 +714,10 @@ static NfcCommand mf_ultralight_poller_handler_request_write_data(MfUltralightPo
         }
 
         if(mf_ultralight_support_feature(features, MfUltralightFeatureSupportPasswordAuth)) {
-            if(!instance->auth_context.auth_success) {
+            MfUltralightConfigPages* config = NULL;
+            bool auth0_disabled =
+                mf_ultralight_get_config_page(tag_data, &config) && config->auth0 == 0xFF;
+            if(!instance->auth_context.auth_success && !auth0_disabled) {
                 FURI_LOG_D(TAG, "Unknown password");
                 instance->mfu_event.type = MfUltralightPollerEventTypeCardLocked;
                 break;


### PR DESCRIPTION
Two bugs fixed in this PR.

**SK6805 / vibro pin conflict (#541)**

`gpio_vibro` and `SK6805_LED_PIN` are both mapped to `GPIOA, LL_GPIO_PIN_8`. `SK6805_update()` calls `SK6805_init()` on every invocation which drives the pin low and reconfigures it, cutting off any active vibration mid-buzz. After the bit-bang loop completes the pin is left at whatever state the final data bit required, not the vibro state.

Fix: read the pin state before the update and restore it afterward.

**NTAG21x write blocked after password clear (#538)**

After clearing a password (`PWD=0x00000000`, `PACK=0x00000000`, `AUTH0=0xFF`) the Flipper incorrectly treats the tag as still protected. Two places were responsible:

- `mf_ultralight_is_all_data_read()` returns false when `PWD==0 && PACK==0`, hiding the Write button in the menu. This is wrong when `AUTH0=0xFF` because there is no active protection regardless of what the password pages contain.
- The write poller rejects writes if `auth_success` is false, even when `AUTH0=0xFF` means no authentication is required at all.

Fix: both checks now skip the password gate when the config page reports `AUTH0=0xFF`.