### PR TITLE
NFC: Add Ventra plugin to Metroflip imports, mark legacy parser deprecated

### DIFF
--- a/applications/main/nfc/plugins/supported_cards/ventra.c
+++ b/applications/main/nfc/plugins/supported_cards/ventra.c
@@ -3,6 +3,9 @@
 // Based on my own research, with...
 // Credit to https://www.lenrek.net/experiments/compass-tickets/ & MetroDroid project for underlying info
 //
+// Deprecated: Ventra parsing has moved to the Metroflip application.
+// This legacy parser may be removed in a future release.
+//
 // This parser can decode the paper single-use and single/multi-day paper passes using Ultralight EV1
 // The plastic cards are DESFire and fully locked down, not much useful info extractable
 // TODO:

--- a/scripts/fbt_tools/fbt_extapps.py
+++ b/scripts/fbt_tools/fbt_extapps.py
@@ -336,6 +336,7 @@ def _validate_app_imports(target, source, env):
             "troika_plugin",
             "trt_plugin",
             "two_cities_plugin",
+            "ventra_plugin",
         ): (
             "metroflip_",
             "bit_slice_to_dec",


### PR DESCRIPTION
# What's new

- Mark existing legacy Ventra-UL parser deprecated -- ported it to Metroflip
- Add ventra plugin to Metroflip imports

-----
# For the reviewer

- [ ] I've uploaded the firmware with this patch to a device and verified its functionality
- [ ] I've confirmed the bug to be fixed / feature to be stable
