### PR TITLE
Improve ISO15693 listener timing and inventory handling

### DIFF
--- a/applications/main/momentum_app/scenes/momentum_app_scene_protocols.c
+++ b/applications/main/momentum_app/scenes/momentum_app_scene_protocols.c
@@ -5,6 +5,7 @@ enum VarItemListIndex {
     VarItemListIndexSubghzBypass,
     VarItemListIndexSubghzExtend,
     VarItemListIndexGpioPins,
+    VarItemListIndexNfcvTiming,
     VarItemListIndexFileNamingPrefix,
 };
 
@@ -28,6 +29,14 @@ static void momentum_app_scene_protocols_file_naming_prefix_changed(VariableItem
     bool value = variable_item_get_current_value_index(item);
     variable_item_set_current_value_text(item, value ? "After" : "Before");
     momentum_settings.file_naming_prefix_after = value;
+    app->save_settings = true;
+}
+
+static void momentum_app_scene_protocols_nfcv_timing_changed(VariableItem* item) {
+    MomentumApp* app = variable_item_get_context(item);
+    bool value = variable_item_get_current_value_index(item);
+    variable_item_set_current_value_text(item, value ? "Fast" : "Compat");
+    momentum_settings.nfcv_fast_timing = value;
     app->save_settings = true;
 }
 
@@ -60,6 +69,16 @@ void momentum_app_scene_protocols_on_enter(void* context) {
 
     item = variable_item_list_add(var_item_list, "GPIO Pins", 0, NULL, app);
     variable_item_set_current_value_text(item, ">");
+
+    item = variable_item_list_add(
+        var_item_list,
+        "NFC-V Timing",
+        2,
+        momentum_app_scene_protocols_nfcv_timing_changed,
+        app);
+    variable_item_set_current_value_index(item, momentum_settings.nfcv_fast_timing);
+    variable_item_set_current_value_text(
+        item, momentum_settings.nfcv_fast_timing ? "Fast" : "Compat");
 
     item = variable_item_list_add(
         var_item_list,

--- a/applications/main/nfc/helpers/protocol_support/iso15693_3/iso15693_3.c
+++ b/applications/main/nfc/helpers/protocol_support/iso15693_3/iso15693_3.c
@@ -83,9 +83,24 @@ static NfcCommand
     NfcApp* instance = context;
     Iso15693_3ListenerEvent* iso15693_3_event = event.event_data;
 
-    if(iso15693_3_event->type == Iso15693_3ListenerEventTypeCustomCommand) {
-        if(furi_string_size(instance->text_box_store) < NFC_LOG_SIZE_MAX) {
-            furi_string_cat_printf(instance->text_box_store, "R:");
+    if(furi_string_size(instance->text_box_store) < NFC_LOG_SIZE_MAX) {
+        if(iso15693_3_event->type == Iso15693_3ListenerEventTypeFieldOn) {
+            furi_string_cat_str(instance->text_box_store, "FIELD ON\n");
+            view_dispatcher_send_custom_event(
+                instance->view_dispatcher, NfcCustomEventListenerUpdate);
+        } else if(iso15693_3_event->type == Iso15693_3ListenerEventTypeFieldOff) {
+            furi_string_cat_str(instance->text_box_store, "FIELD OFF\n");
+            view_dispatcher_send_custom_event(
+                instance->view_dispatcher, NfcCustomEventListenerUpdate);
+        } else if(
+            iso15693_3_event->type == Iso15693_3ListenerEventTypeRequest ||
+            iso15693_3_event->type == Iso15693_3ListenerEventTypeRequestError ||
+            iso15693_3_event->type == Iso15693_3ListenerEventTypeResponse) {
+            furi_string_cat_printf(
+                instance->text_box_store,
+                iso15693_3_event->type == Iso15693_3ListenerEventTypeRequest       ? "R:" :
+                iso15693_3_event->type == Iso15693_3ListenerEventTypeRequestError  ? "E:" :
+                                                                                      "T:");
             for(size_t i = 0; i < bit_buffer_get_size_bytes(iso15693_3_event->data->buffer); i++) {
                 furi_string_cat_printf(
                     instance->text_box_store,

--- a/applications/main/nfc/helpers/protocol_support/slix/slix.c
+++ b/applications/main/nfc/helpers/protocol_support/slix/slix.c
@@ -85,9 +85,24 @@ static NfcCommand nfc_scene_emulate_listener_callback_slix(NfcGenericEvent event
     NfcApp* instance = context;
     SlixListenerEvent* slix_event = event.event_data;
 
-    if(slix_event->type == SlixListenerEventTypeCustomCommand) {
-        if(furi_string_size(instance->text_box_store) < NFC_LOG_SIZE_MAX) {
-            furi_string_cat_printf(instance->text_box_store, "R:");
+    if(furi_string_size(instance->text_box_store) < NFC_LOG_SIZE_MAX) {
+        if(slix_event->type == SlixListenerEventTypeFieldOn) {
+            furi_string_cat_str(instance->text_box_store, "FIELD ON\n");
+            view_dispatcher_send_custom_event(
+                instance->view_dispatcher, NfcCustomEventListenerUpdate);
+        } else if(slix_event->type == SlixListenerEventTypeFieldOff) {
+            furi_string_cat_str(instance->text_box_store, "FIELD OFF\n");
+            view_dispatcher_send_custom_event(
+                instance->view_dispatcher, NfcCustomEventListenerUpdate);
+        } else if(
+            slix_event->type == SlixListenerEventTypeRequest ||
+            slix_event->type == SlixListenerEventTypeRequestError ||
+            slix_event->type == SlixListenerEventTypeResponse) {
+            furi_string_cat_printf(
+                instance->text_box_store,
+                slix_event->type == SlixListenerEventTypeRequest       ? "R:" :
+                slix_event->type == SlixListenerEventTypeRequestError  ? "E:" :
+                                                                          "T:");
             for(size_t i = 0; i < bit_buffer_get_size_bytes(slix_event->data->buffer); i++) {
                 furi_string_cat_printf(
                     instance->text_box_store,

--- a/lib/digital_signal/presets/nfc/iso15693_signal.c
+++ b/lib/digital_signal/presets/nfc/iso15693_signal.c
@@ -11,13 +11,18 @@
 #define ISO15693_SIGNAL_COEFF_HI (1U)
 #define ISO15693_SIGNAL_COEFF_LO (4U)
 
-#define ISO15693_SIGNAL_ZERO_EDGES (16U)
-#define ISO15693_SIGNAL_ONE_EDGES  (ISO15693_SIGNAL_ZERO_EDGES + 1U)
-#define ISO15693_SIGNAL_EOF_EDGES  (64U)
-#define ISO15693_SIGNAL_SOF_EDGES  (ISO15693_SIGNAL_EOF_EDGES + 1U)
-#define ISO15693_SIGNAL_EDGES      (1350U)
+#define ISO15693_SIGNAL_SINGLE_ZERO_EDGES (16U)
+#define ISO15693_SIGNAL_SINGLE_ONE_EDGES  (ISO15693_SIGNAL_SINGLE_ZERO_EDGES + 1U)
+#define ISO15693_SIGNAL_SINGLE_EOF_EDGES  (64U)
+#define ISO15693_SIGNAL_SINGLE_SOF_EDGES  (ISO15693_SIGNAL_SINGLE_EOF_EDGES + 1U)
+
+#define ISO15693_SIGNAL_DUAL_ZERO_EDGES (34U)
+#define ISO15693_SIGNAL_DUAL_ONE_EDGES  (34U)
+#define ISO15693_SIGNAL_DUAL_EOF_EDGES  (136U)
+#define ISO15693_SIGNAL_DUAL_SOF_EDGES  (136U)
 
 #define ISO15693_SIGNAL_FC     (13.56e6)
+#define ISO15693_SIGNAL_FC_14  (14.0e11 / ISO15693_SIGNAL_FC)
 #define ISO15693_SIGNAL_FC_16  (16.0e11 / ISO15693_SIGNAL_FC)
 #define ISO15693_SIGNAL_FC_256 (256.0e11 / ISO15693_SIGNAL_FC)
 #define ISO15693_SIGNAL_FC_768 (768.0e11 / ISO15693_SIGNAL_FC)
@@ -30,11 +35,17 @@ typedef enum {
     Iso15693SignalIndexNum,
 } Iso15693SignalIndex;
 
+typedef enum {
+    Iso15693SignalSubcarrierOne,
+    Iso15693SignalSubcarrierTwo,
+    Iso15693SignalSubcarrierNum,
+} Iso15693SignalSubcarrier;
+
 typedef DigitalSignal* Iso15693SignalBank[Iso15693SignalIndexNum];
 
 struct Iso15693Signal {
     DigitalSequence* tx_sequence;
-    Iso15693SignalBank banks[Iso15693SignalDataRateNum];
+    Iso15693SignalBank banks[Iso15693SignalDataRateNum][Iso15693SignalSubcarrierNum];
 };
 
 // Add an unmodulated signal for the length of Fc / 256 * k (where k = 1 or 4)
@@ -45,108 +56,182 @@ static void iso15693_add_silence(DigitalSignal* signal, Iso15693SignalDataRate d
 }
 
 // Add 8 * k subcarrier pulses of Fc / 16 (where k = 1 or 4)
-static void iso15693_add_subcarrier(DigitalSignal* signal, Iso15693SignalDataRate data_rate) {
+static void iso15693_add_single_subcarrier(
+    DigitalSignal* signal,
+    Iso15693SignalDataRate data_rate) {
     const uint32_t k = data_rate == Iso15693SignalDataRateHi ? ISO15693_SIGNAL_COEFF_HI :
                                                                ISO15693_SIGNAL_COEFF_LO;
-    for(uint32_t i = 0; i < ISO15693_SIGNAL_ZERO_EDGES * k; ++i) {
+    for(uint32_t i = 0; i < ISO15693_SIGNAL_SINGLE_ZERO_EDGES * k; ++i) {
         digital_signal_add_period_with_level(signal, ISO15693_SIGNAL_FC_16, !(i % 2));
     }
 }
 
-static void iso15693_add_bit(DigitalSignal* signal, Iso15693SignalDataRate data_rate, bool bit) {
+static void iso15693_add_dual_fc32(DigitalSignal* signal, uint32_t pulses) {
+    for(uint32_t i = 0; i < pulses * 2; ++i) {
+        digital_signal_add_period_with_level(signal, ISO15693_SIGNAL_FC_16, !(i % 2));
+    }
+}
+
+static void iso15693_add_dual_fc28(DigitalSignal* signal, uint32_t pulses) {
+    for(uint32_t i = 0; i < pulses * 2; ++i) {
+        digital_signal_add_period_with_level(signal, ISO15693_SIGNAL_FC_14, !(i % 2));
+    }
+}
+
+static void
+    iso15693_add_single_bit(DigitalSignal* signal, Iso15693SignalDataRate data_rate, bool bit) {
     if(bit) {
         iso15693_add_silence(signal, data_rate);
-        iso15693_add_subcarrier(signal, data_rate);
+        iso15693_add_single_subcarrier(signal, data_rate);
     } else {
-        iso15693_add_subcarrier(signal, data_rate);
+        iso15693_add_single_subcarrier(signal, data_rate);
         iso15693_add_silence(signal, data_rate);
     }
 }
 
-static inline void iso15693_add_sof(DigitalSignal* signal, Iso15693SignalDataRate data_rate) {
+static void iso15693_add_dual_bit(DigitalSignal* signal, Iso15693SignalDataRate data_rate, bool bit) {
+    const uint32_t k = data_rate == Iso15693SignalDataRateHi ? ISO15693_SIGNAL_COEFF_HI :
+                                                               ISO15693_SIGNAL_COEFF_LO;
+    if(bit) {
+        iso15693_add_dual_fc28(signal, 9U * k);
+        iso15693_add_dual_fc32(signal, 8U * k);
+    } else {
+        iso15693_add_dual_fc32(signal, 8U * k);
+        iso15693_add_dual_fc28(signal, 9U * k);
+    }
+}
+
+static inline void iso15693_add_single_sof(DigitalSignal* signal, Iso15693SignalDataRate data_rate) {
     // Not adding silence since it only increases response time
 
     for(uint32_t i = 0; i < ISO15693_SIGNAL_FC_768 / ISO15693_SIGNAL_FC_256; ++i) {
-        iso15693_add_subcarrier(signal, data_rate);
+        iso15693_add_single_subcarrier(signal, data_rate);
     }
 
-    iso15693_add_bit(signal, data_rate, true);
+    iso15693_add_single_bit(signal, data_rate, true);
 }
 
-static inline void iso15693_add_eof(DigitalSignal* signal, Iso15693SignalDataRate data_rate) {
-    iso15693_add_bit(signal, data_rate, false);
+static inline void iso15693_add_single_eof(DigitalSignal* signal, Iso15693SignalDataRate data_rate) {
+    iso15693_add_single_bit(signal, data_rate, false);
 
     for(uint32_t i = 0; i < ISO15693_SIGNAL_FC_768 / ISO15693_SIGNAL_FC_256; ++i) {
-        iso15693_add_subcarrier(signal, data_rate);
+        iso15693_add_single_subcarrier(signal, data_rate);
     }
 
     // Not adding silence since it does nothing here
 }
 
-static inline uint32_t
-    iso15693_get_sequence_index(Iso15693SignalIndex index, Iso15693SignalDataRate data_rate) {
-    return index + data_rate * Iso15693SignalIndexNum;
+static inline void iso15693_add_dual_sof(DigitalSignal* signal, Iso15693SignalDataRate data_rate) {
+    const uint32_t k = data_rate == Iso15693SignalDataRateHi ? ISO15693_SIGNAL_COEFF_HI :
+                                                               ISO15693_SIGNAL_COEFF_LO;
+    iso15693_add_dual_fc28(signal, 27U * k);
+    iso15693_add_dual_fc32(signal, 24U * k);
+    iso15693_add_dual_bit(signal, data_rate, true);
 }
 
-static inline void
-    iso15693_add_byte(Iso15693Signal* instance, Iso15693SignalDataRate data_rate, uint8_t byte) {
+static inline void iso15693_add_dual_eof(DigitalSignal* signal, Iso15693SignalDataRate data_rate) {
+    const uint32_t k = data_rate == Iso15693SignalDataRateHi ? ISO15693_SIGNAL_COEFF_HI :
+                                                               ISO15693_SIGNAL_COEFF_LO;
+    iso15693_add_dual_bit(signal, data_rate, false);
+    iso15693_add_dual_fc32(signal, 24U * k);
+    iso15693_add_dual_fc28(signal, 27U * k);
+}
+
+static inline uint32_t iso15693_get_sequence_index(
+    Iso15693SignalIndex index,
+    Iso15693SignalDataRate data_rate,
+    Iso15693SignalSubcarrier subcarrier) {
+    return index + Iso15693SignalIndexNum * (data_rate + Iso15693SignalDataRateNum * subcarrier);
+}
+
+static inline void iso15693_add_byte(
+    Iso15693Signal* instance,
+    Iso15693SignalDataRate data_rate,
+    Iso15693SignalSubcarrier subcarrier,
+    uint8_t byte) {
     for(size_t i = 0; i < BITS_IN_BYTE; i++) {
         const uint8_t bit = byte & (1U << i);
         digital_sequence_add_signal(
             instance->tx_sequence,
             iso15693_get_sequence_index(
-                bit ? Iso15693SignalIndexOne : Iso15693SignalIndexZero, data_rate));
+                bit ? Iso15693SignalIndexOne : Iso15693SignalIndexZero, data_rate, subcarrier));
     }
 }
 
 static inline void iso15693_signal_encode(
     Iso15693Signal* instance,
     Iso15693SignalDataRate data_rate,
+    Iso15693SignalSubcarrier subcarrier,
     const uint8_t* tx_data,
     size_t tx_data_size) {
     digital_sequence_add_signal(
-        instance->tx_sequence, iso15693_get_sequence_index(Iso15693SignalIndexSof, data_rate));
+        instance->tx_sequence,
+        iso15693_get_sequence_index(Iso15693SignalIndexSof, data_rate, subcarrier));
 
     for(size_t i = 0; i < tx_data_size; i++) {
-        iso15693_add_byte(instance, data_rate, tx_data[i]);
+        iso15693_add_byte(instance, data_rate, subcarrier, tx_data[i]);
     }
 
     digital_sequence_add_signal(
-        instance->tx_sequence, iso15693_get_sequence_index(Iso15693SignalIndexEof, data_rate));
+        instance->tx_sequence,
+        iso15693_get_sequence_index(Iso15693SignalIndexEof, data_rate, subcarrier));
 }
 
-static void iso15693_signal_bank_fill(Iso15693Signal* instance, Iso15693SignalDataRate data_rate) {
+static void iso15693_signal_bank_fill(
+    Iso15693Signal* instance,
+    Iso15693SignalDataRate data_rate,
+    Iso15693SignalSubcarrier subcarrier) {
     const uint32_t k = data_rate == Iso15693SignalDataRateHi ? ISO15693_SIGNAL_COEFF_HI :
                                                                ISO15693_SIGNAL_COEFF_LO;
-    DigitalSignal** bank = instance->banks[data_rate];
+    DigitalSignal** bank = instance->banks[data_rate][subcarrier];
 
-    bank[Iso15693SignalIndexSof] = digital_signal_alloc(ISO15693_SIGNAL_SOF_EDGES * k);
-    bank[Iso15693SignalIndexEof] = digital_signal_alloc(ISO15693_SIGNAL_EOF_EDGES * k);
-    bank[Iso15693SignalIndexOne] = digital_signal_alloc(ISO15693_SIGNAL_ONE_EDGES * k);
-    bank[Iso15693SignalIndexZero] = digital_signal_alloc(ISO15693_SIGNAL_ZERO_EDGES * k);
+    if(subcarrier == Iso15693SignalSubcarrierOne) {
+        bank[Iso15693SignalIndexSof] =
+            digital_signal_alloc(ISO15693_SIGNAL_SINGLE_SOF_EDGES * k);
+        bank[Iso15693SignalIndexEof] =
+            digital_signal_alloc(ISO15693_SIGNAL_SINGLE_EOF_EDGES * k);
+        bank[Iso15693SignalIndexOne] =
+            digital_signal_alloc(ISO15693_SIGNAL_SINGLE_ONE_EDGES * k);
+        bank[Iso15693SignalIndexZero] =
+            digital_signal_alloc(ISO15693_SIGNAL_SINGLE_ZERO_EDGES * k);
 
-    iso15693_add_sof(bank[Iso15693SignalIndexSof], data_rate);
-    iso15693_add_eof(bank[Iso15693SignalIndexEof], data_rate);
-    iso15693_add_bit(bank[Iso15693SignalIndexOne], data_rate, true);
-    iso15693_add_bit(bank[Iso15693SignalIndexZero], data_rate, false);
+        iso15693_add_single_sof(bank[Iso15693SignalIndexSof], data_rate);
+        iso15693_add_single_eof(bank[Iso15693SignalIndexEof], data_rate);
+        iso15693_add_single_bit(bank[Iso15693SignalIndexOne], data_rate, true);
+        iso15693_add_single_bit(bank[Iso15693SignalIndexZero], data_rate, false);
+    } else {
+        bank[Iso15693SignalIndexSof] = digital_signal_alloc(ISO15693_SIGNAL_DUAL_SOF_EDGES * k);
+        bank[Iso15693SignalIndexEof] = digital_signal_alloc(ISO15693_SIGNAL_DUAL_EOF_EDGES * k);
+        bank[Iso15693SignalIndexOne] = digital_signal_alloc(ISO15693_SIGNAL_DUAL_ONE_EDGES * k);
+        bank[Iso15693SignalIndexZero] = digital_signal_alloc(ISO15693_SIGNAL_DUAL_ZERO_EDGES * k);
+
+        iso15693_add_dual_sof(bank[Iso15693SignalIndexSof], data_rate);
+        iso15693_add_dual_eof(bank[Iso15693SignalIndexEof], data_rate);
+        iso15693_add_dual_bit(bank[Iso15693SignalIndexOne], data_rate, true);
+        iso15693_add_dual_bit(bank[Iso15693SignalIndexZero], data_rate, false);
+    }
 }
 
-static void
-    iso15693_signal_bank_clear(Iso15693Signal* instance, Iso15693SignalDataRate data_rate) {
-    DigitalSignal** bank = instance->banks[data_rate];
+static void iso15693_signal_bank_clear(
+    Iso15693Signal* instance,
+    Iso15693SignalDataRate data_rate,
+    Iso15693SignalSubcarrier subcarrier) {
+    DigitalSignal** bank = instance->banks[data_rate][subcarrier];
 
     for(uint32_t i = 0; i < Iso15693SignalIndexNum; ++i) {
         digital_signal_free(bank[i]);
     }
 }
 
-static void
-    iso15693_signal_bank_register(Iso15693Signal* instance, Iso15693SignalDataRate data_rate) {
+static void iso15693_signal_bank_register(
+    Iso15693Signal* instance,
+    Iso15693SignalDataRate data_rate,
+    Iso15693SignalSubcarrier subcarrier) {
     for(uint32_t i = 0; i < Iso15693SignalIndexNum; ++i) {
         digital_sequence_register_signal(
             instance->tx_sequence,
-            iso15693_get_sequence_index(i, data_rate),
-            instance->banks[data_rate][i]);
+            iso15693_get_sequence_index(i, data_rate, subcarrier),
+            instance->banks[data_rate][subcarrier][i]);
     }
 }
 
@@ -158,8 +243,10 @@ Iso15693Signal* iso15693_signal_alloc(const GpioPin* pin) {
     instance->tx_sequence = digital_sequence_alloc(ISO15693_SIGNAL_BUFFER_SIZE, pin);
 
     for(uint32_t i = 0; i < Iso15693SignalDataRateNum; ++i) {
-        iso15693_signal_bank_fill(instance, i);
-        iso15693_signal_bank_register(instance, i);
+        for(uint32_t j = 0; j < Iso15693SignalSubcarrierNum; ++j) {
+            iso15693_signal_bank_fill(instance, i, j);
+            iso15693_signal_bank_register(instance, i, j);
+        }
     }
 
     return instance;
@@ -171,7 +258,9 @@ void iso15693_signal_free(Iso15693Signal* instance) {
     digital_sequence_free(instance->tx_sequence);
 
     for(uint32_t i = 0; i < Iso15693SignalDataRateNum; ++i) {
-        iso15693_signal_bank_clear(instance, i);
+        for(uint32_t j = 0; j < Iso15693SignalSubcarrierNum; ++j) {
+            iso15693_signal_bank_clear(instance, i, j);
+        }
     }
 
     free(instance);
@@ -186,22 +275,29 @@ void iso15693_signal_tx(
     furi_assert(data_rate < Iso15693SignalDataRateNum);
     furi_assert(tx_data);
 
+    const Iso15693SignalSubcarrier subcarrier = Iso15693SignalSubcarrierOne;
+
     FURI_CRITICAL_ENTER();
     digital_sequence_clear(instance->tx_sequence);
-    iso15693_signal_encode(instance, data_rate, tx_data, tx_data_size);
+    iso15693_signal_encode(instance, data_rate, subcarrier, tx_data, tx_data_size);
     digital_sequence_transmit(instance->tx_sequence);
 
     FURI_CRITICAL_EXIT();
 }
 
-void iso15693_signal_tx_sof(Iso15693Signal* instance, Iso15693SignalDataRate data_rate) {
+void iso15693_signal_tx_sof(
+    Iso15693Signal* instance,
+    Iso15693SignalDataRate data_rate) {
     furi_assert(instance);
     furi_assert(data_rate < Iso15693SignalDataRateNum);
+
+    const Iso15693SignalSubcarrier subcarrier = Iso15693SignalSubcarrierOne;
 
     FURI_CRITICAL_ENTER();
     digital_sequence_clear(instance->tx_sequence);
     digital_sequence_add_signal(
-        instance->tx_sequence, iso15693_get_sequence_index(Iso15693SignalIndexSof, data_rate));
+        instance->tx_sequence,
+        iso15693_get_sequence_index(Iso15693SignalIndexSof, data_rate, subcarrier));
     digital_sequence_transmit(instance->tx_sequence);
 
     FURI_CRITICAL_EXIT();

--- a/lib/digital_signal/presets/nfc/iso15693_signal.h
+++ b/lib/digital_signal/presets/nfc/iso15693_signal.h
@@ -66,7 +66,9 @@ void iso15693_signal_tx(
  * @param[in] instance pointer to the instance used in transmission.
  * @param[in] data_rate data rate to transmit at.
  */
-void iso15693_signal_tx_sof(Iso15693Signal* instance, Iso15693SignalDataRate data_rate);
+void iso15693_signal_tx_sof(
+    Iso15693Signal* instance,
+    Iso15693SignalDataRate data_rate);
 
 #ifdef __cplusplus
 }

--- a/lib/momentum/settings.c
+++ b/lib/momentum/settings.c
@@ -43,6 +43,7 @@ MomentumSettings momentum_settings = {
     .spi_nrf24_handle = SpiDefault, // &furi_hal_spi_bus_handle_external
     .uart_esp_channel = FuriHalSerialIdUsart, // pin 13,14
     .uart_nmea_channel = FuriHalSerialIdUsart, // pin 13,14
+    .nfcv_fast_timing = true, // Fast
     .file_naming_prefix_after = false, // Before
     .spoof_color = FuriHalVersionColorUnknown, // Real
     .rpc_color_fg = {{ScreenColorModeDefault, {.value = 0x000000}}}, // Default Black
@@ -117,6 +118,7 @@ static const struct {
     {setting_enum(spi_nrf24_handle, SpiCount)},
     {setting_enum(uart_esp_channel, FuriHalSerialIdMax)},
     {setting_enum(uart_nmea_channel, FuriHalSerialIdMax)},
+    {setting_bool(nfcv_fast_timing)},
     {setting_bool(file_naming_prefix_after)},
     {setting_enum(spoof_color, FuriHalVersionColorCount)},
     {setting_uint(rpc_color_fg, 0x000000, 0xFFFFFF)},

--- a/lib/momentum/settings.h
+++ b/lib/momentum/settings.h
@@ -100,6 +100,7 @@ typedef struct {
     SpiHandle spi_nrf24_handle;
     FuriHalSerialId uart_esp_channel;
     FuriHalSerialId uart_nmea_channel;
+    bool nfcv_fast_timing;
     bool file_naming_prefix_after;
     FuriHalVersionColor spoof_color;
     ScreenFrameColor rpc_color_fg;

--- a/lib/nfc/protocols/iso15693_3/iso15693_3_listener.c
+++ b/lib/nfc/protocols/iso15693_3/iso15693_3_listener.c
@@ -14,6 +14,8 @@ Iso15693_3Listener* iso15693_3_listener_alloc(Nfc* nfc, Iso15693_3Data* data) {
     Iso15693_3Listener* instance = malloc(sizeof(Iso15693_3Listener));
     instance->nfc = nfc;
     instance->data = data;
+    instance->state = Iso15693_3ListenerStateReady;
+    instance->session_state = (Iso15693_3ListenerSessionState){0};
 
     instance->tx_buffer = bit_buffer_alloc(ISO15693_3_LISTENER_BUFFER_SIZE);
 
@@ -62,10 +64,23 @@ NfcCommand iso15693_3_listener_run(NfcGenericEvent event, void* context) {
     NfcEvent* nfc_event = event.event_data;
     NfcCommand command = NfcCommandContinue;
 
-    if(nfc_event->type == NfcEventTypeRxEnd) {
+    if(nfc_event->type == NfcEventTypeFieldOn) {
+        if(instance->callback) {
+            instance->iso15693_3_event.type = Iso15693_3ListenerEventTypeFieldOn;
+            command = instance->callback(instance->generic_event, instance->context);
+        }
+    } else if(nfc_event->type == NfcEventTypeFieldOff) {
+        instance->session_state = (Iso15693_3ListenerSessionState){0};
+        if(instance->callback) {
+            instance->iso15693_3_event.type = Iso15693_3ListenerEventTypeFieldOff;
+            command = instance->callback(instance->generic_event, instance->context);
+        }
+    } else if(nfc_event->type == NfcEventTypeRxEnd) {
         BitBuffer* rx_buffer = nfc_event->data.buffer;
 
-        bit_buffer_reset(instance->tx_buffer);
+        if(bit_buffer_get_size(rx_buffer) != 0) {
+            bit_buffer_reset(instance->tx_buffer);
+        }
         if(iso13239_crc_check(Iso13239CrcTypeDefault, rx_buffer)) {
             iso13239_crc_trim(rx_buffer);
 
@@ -82,16 +97,47 @@ NfcCommand iso15693_3_listener_run(NfcGenericEvent event, void* context) {
                 iso15693_3_listener_process_uid_mismatch(instance, rx_buffer);
             }
 
+            if(instance->callback) {
+                const NfcCommand prev_command = command;
+                instance->iso15693_3_event.type = Iso15693_3ListenerEventTypeRequest;
+                instance->iso15693_3_event.data->buffer = rx_buffer;
+                command = instance->callback(instance->generic_event, instance->context);
+                if(prev_command != NfcCommandContinue) {
+                    command = prev_command;
+                }
+            }
+            if(instance->callback && bit_buffer_get_size(instance->tx_buffer) &&
+               !instance->session_state.wait_for_eof) {
+                const NfcCommand prev_command = command;
+                instance->iso15693_3_event.type = Iso15693_3ListenerEventTypeResponse;
+                instance->iso15693_3_event.data->buffer = instance->tx_buffer;
+                command = instance->callback(instance->generic_event, instance->context);
+                if(prev_command != NfcCommandContinue) {
+                    command = prev_command;
+                }
+            }
+
         } else if(bit_buffer_get_size(rx_buffer) == 0) {
             // Special case: Single EOF
             const Iso15693_3Error error = iso15693_3_listener_process_single_eof(instance);
-            if(error == Iso15693_3ErrorUnexpectedResponse) {
+            if(error == Iso15693_3ErrorNone) {
+                if(instance->callback && bit_buffer_get_size(instance->tx_buffer)) {
+                    instance->iso15693_3_event.type = Iso15693_3ListenerEventTypeResponse;
+                    instance->iso15693_3_event.data->buffer = instance->tx_buffer;
+                    command = instance->callback(instance->generic_event, instance->context);
+                }
+            } else if(error == Iso15693_3ErrorUnexpectedResponse) {
                 if(instance->callback) {
                     instance->iso15693_3_event.type = Iso15693_3ListenerEventTypeSingleEof;
                     command = instance->callback(instance->generic_event, instance->context);
                 }
             }
         } else {
+            if(instance->callback) {
+                instance->iso15693_3_event.type = Iso15693_3ListenerEventTypeRequestError;
+                instance->iso15693_3_event.data->buffer = rx_buffer;
+                command = instance->callback(instance->generic_event, instance->context);
+            }
             FURI_LOG_D(
                 TAG, "Wrong CRC, buffer size: %zu", bit_buffer_get_size(nfc_event->data.buffer));
         }

--- a/lib/nfc/protocols/iso15693_3/iso15693_3_listener.h
+++ b/lib/nfc/protocols/iso15693_3/iso15693_3_listener.h
@@ -11,7 +11,11 @@ extern "C" {
 typedef struct Iso15693_3Listener Iso15693_3Listener;
 
 typedef enum {
+    Iso15693_3ListenerEventTypeFieldOn,
     Iso15693_3ListenerEventTypeFieldOff,
+    Iso15693_3ListenerEventTypeRequest,
+    Iso15693_3ListenerEventTypeRequestError,
+    Iso15693_3ListenerEventTypeResponse,
     Iso15693_3ListenerEventTypeCustomCommand,
     Iso15693_3ListenerEventTypeSingleEof,
 } Iso15693_3ListenerEventType;

--- a/lib/nfc/protocols/iso15693_3/iso15693_3_listener_i.c
+++ b/lib/nfc/protocols/iso15693_3/iso15693_3_listener_i.c
@@ -848,8 +848,6 @@ Iso15693_3Error
             (const Iso15693_3RequestLayout*)bit_buffer_get_data(rx_buffer);
 
         Iso15693_3ListenerSessionState* session_state = &instance->session_state;
-        session_state->wait_for_eof = false;
-        session_state->inventory_wait_for_slot = false;
 
         if((request->flags & ISO15693_3_REQ_FLAG_INVENTORY_T5) == 0) {
             session_state->selected = request->flags & ISO15693_3_REQ_FLAG_T4_SELECTED;

--- a/lib/nfc/protocols/iso15693_3/iso15693_3_listener_i.c
+++ b/lib/nfc/protocols/iso15693_3/iso15693_3_listener_i.c
@@ -3,6 +3,7 @@
 #include <nfc/helpers/iso13239_crc.h>
 
 #define TAG "Iso15693_3Listener"
+#define BITS_IN_BYTE (8U)
 
 typedef Iso15693_3Error (*Iso15693_3RequestHandler)(
     Iso15693_3Listener* instance,
@@ -14,6 +15,50 @@ typedef struct {
     Iso15693_3RequestHandler mandatory[ISO15693_3_MANDATORY_COUNT];
     Iso15693_3RequestHandler optional[ISO15693_3_OPTIONAL_COUNT];
 } Iso15693_3ListenerHandlerTable;
+
+static bool iso15693_3_listener_inventory_mask_matches(
+    const Iso15693_3Data* data,
+    const uint8_t* mask,
+    uint8_t mask_bits) {
+    furi_assert(data);
+    furi_assert(mask);
+
+    bool matches = true;
+
+    for(uint8_t i = 0; i < mask_bits; ++i) {
+        const uint8_t mask_bit = (mask[i / 8] >> (i % 8)) & 1U;
+        const uint8_t uid_air_byte = data->uid[ISO15693_3_UID_SIZE - 1 - (i / 8)];
+        const uint8_t uid_bit = (uid_air_byte >> (i % 8)) & 1U;
+
+        if(mask_bit != uid_bit) {
+            matches = false;
+            break;
+        }
+    }
+
+    return matches;
+}
+
+static uint8_t iso15693_3_listener_get_uid_air_bit(const Iso15693_3Data* data, uint8_t bit_num) {
+    furi_assert(data);
+    furi_assert(bit_num < ISO15693_3_UID_SIZE * BITS_IN_BYTE);
+
+    const uint8_t uid_air_byte = data->uid[ISO15693_3_UID_SIZE - 1 - (bit_num / BITS_IN_BYTE)];
+    return (uid_air_byte >> (bit_num % BITS_IN_BYTE)) & 1U;
+}
+
+static uint8_t
+    iso15693_3_listener_get_inventory_slot(const Iso15693_3Data* data, uint8_t mask_bits) {
+    uint8_t slot = 0;
+
+    for(uint8_t i = 0; i < 4; ++i) {
+        const uint8_t uid_bit_num = mask_bits + i;
+        if(uid_bit_num >= ISO15693_3_UID_SIZE * BITS_IN_BYTE) break;
+        slot |= iso15693_3_listener_get_uid_air_bit(data, uid_bit_num) << i;
+    }
+
+    return slot;
+}
 
 static Iso15693_3Error
     iso15693_3_listener_extension_handler(Iso15693_3Listener* instance, uint32_t command, ...) {
@@ -65,20 +110,43 @@ static Iso15693_3Error iso15693_3_listener_inventory_handler(
             const uint8_t afi = *data++;
             // When AFI flag is set, ignore non-matching requests
             if(afi != 0) {
-                if(afi != instance->data->system_info.afi) break;
+                if(afi != instance->data->system_info.afi) {
+                    error = Iso15693_3ErrorIgnore;
+                    break;
+                }
             }
         }
 
-        const uint8_t mask_len = *data++;
-        const size_t data_size_required = data_size_min + mask_len;
+        const uint8_t mask_len_bits = *data++;
+        const size_t mask_len_bytes = (mask_len_bits + BITS_IN_BYTE - 1) / BITS_IN_BYTE;
+        const size_t data_size_required = data_size_min + mask_len_bytes;
 
-        if(data_size != data_size_required) {
+        if(mask_len_bits > ISO15693_3_UID_SIZE * BITS_IN_BYTE) {
+            error = Iso15693_3ErrorFormat;
+            break;
+        } else if(data_size != data_size_required) {
             error = Iso15693_3ErrorFormat;
             break;
         }
 
-        if(mask_len != 0) {
-            // TODO FL-3633: Take mask_len and mask_value into account (if present)
+        if(mask_len_bits != 0) {
+            if(!iso15693_3_listener_inventory_mask_matches(instance->data, data, mask_len_bits)) {
+                error = Iso15693_3ErrorIgnore;
+                break;
+            }
+        }
+
+        instance->session_state.wait_for_eof = false;
+        instance->session_state.inventory_wait_for_slot = false;
+        const bool single_slot = flags & ISO15693_3_REQ_FLAG_T5_N_SLOTS_1;
+        if(!single_slot) {
+            const uint8_t slot = iso15693_3_listener_get_inventory_slot(
+                instance->data, mask_len_bits);
+            if(slot != 0) {
+                instance->session_state.wait_for_eof = true;
+                instance->session_state.inventory_wait_for_slot = true;
+                instance->session_state.inventory_slot = slot;
+            }
         }
 
         error = iso15693_3_listener_extension_handler(instance, ISO15693_3_CMD_INVENTORY);
@@ -780,6 +848,8 @@ Iso15693_3Error
             (const Iso15693_3RequestLayout*)bit_buffer_get_data(rx_buffer);
 
         Iso15693_3ListenerSessionState* session_state = &instance->session_state;
+        session_state->wait_for_eof = false;
+        session_state->inventory_wait_for_slot = false;
 
         if((request->flags & ISO15693_3_REQ_FLAG_INVENTORY_T5) == 0) {
             session_state->selected = request->flags & ISO15693_3_REQ_FLAG_T4_SELECTED;
@@ -858,6 +928,15 @@ Iso15693_3Error iso15693_3_listener_process_single_eof(Iso15693_3Listener* insta
         if(!instance->session_state.wait_for_eof) {
             error = Iso15693_3ErrorUnexpectedResponse;
             break;
+        }
+
+        if(instance->session_state.inventory_wait_for_slot) {
+            if(instance->session_state.inventory_slot > 1) {
+                instance->session_state.inventory_slot--;
+                error = Iso15693_3ErrorIgnore;
+                break;
+            }
+            instance->session_state.inventory_wait_for_slot = false;
         }
 
         instance->session_state.wait_for_eof = false;

--- a/lib/nfc/protocols/iso15693_3/iso15693_3_listener_i.h
+++ b/lib/nfc/protocols/iso15693_3/iso15693_3_listener_i.h
@@ -32,6 +32,8 @@ typedef struct {
     bool selected;
     bool addressed;
     bool wait_for_eof;
+    bool inventory_wait_for_slot;
+    uint8_t inventory_slot;
 } Iso15693_3ListenerSessionState;
 
 typedef Iso15693_3Error (*Iso15693_3ExtensionHandler)(void* context, va_list args);

--- a/lib/nfc/protocols/slix/slix_listener.c
+++ b/lib/nfc/protocols/slix/slix_listener.c
@@ -60,7 +60,35 @@ static NfcCommand slix_listener_run(NfcGenericEvent event, void* context) {
     BitBuffer* rx_buffer = iso15693_3_event->data->buffer;
     NfcCommand command = NfcCommandContinue;
 
-    if(iso15693_3_event->type == Iso15693_3ListenerEventTypeCustomCommand) {
+    if(iso15693_3_event->type == Iso15693_3ListenerEventTypeFieldOn) {
+        if(instance->callback) {
+            instance->slix_event.type = SlixListenerEventTypeFieldOn;
+            command = instance->callback(instance->generic_event, instance->context);
+        }
+    } else if(iso15693_3_event->type == Iso15693_3ListenerEventTypeFieldOff) {
+        if(instance->callback) {
+            instance->slix_event.type = SlixListenerEventTypeFieldOff;
+            command = instance->callback(instance->generic_event, instance->context);
+        }
+    } else if(iso15693_3_event->type == Iso15693_3ListenerEventTypeRequest) {
+        if(instance->callback) {
+            instance->slix_event.type = SlixListenerEventTypeRequest;
+            instance->slix_event.data->buffer = rx_buffer;
+            command = instance->callback(instance->generic_event, instance->context);
+        }
+    } else if(iso15693_3_event->type == Iso15693_3ListenerEventTypeRequestError) {
+        if(instance->callback) {
+            instance->slix_event.type = SlixListenerEventTypeRequestError;
+            instance->slix_event.data->buffer = rx_buffer;
+            command = instance->callback(instance->generic_event, instance->context);
+        }
+    } else if(iso15693_3_event->type == Iso15693_3ListenerEventTypeResponse) {
+        if(instance->callback) {
+            instance->slix_event.type = SlixListenerEventTypeResponse;
+            instance->slix_event.data->buffer = rx_buffer;
+            command = instance->callback(instance->generic_event, instance->context);
+        }
+    } else if(iso15693_3_event->type == Iso15693_3ListenerEventTypeCustomCommand) {
         const SlixError error = slix_listener_process_request(instance, rx_buffer);
         if(error == SlixErrorWrongPassword) {
             command = NfcCommandSleep;

--- a/lib/nfc/protocols/slix/slix_listener.h
+++ b/lib/nfc/protocols/slix/slix_listener.h
@@ -11,7 +11,11 @@ extern "C" {
 typedef struct SlixListener SlixListener;
 
 typedef enum {
+    SlixListenerEventTypeFieldOn,
     SlixListenerEventTypeFieldOff,
+    SlixListenerEventTypeRequest,
+    SlixListenerEventTypeRequestError,
+    SlixListenerEventTypeResponse,
     SlixListenerEventTypeCustomCommand,
 } SlixListenerEventType;
 

--- a/targets/f7/furi_hal/furi_hal_nfc_iso15693.c
+++ b/targets/f7/furi_hal/furi_hal_nfc_iso15693.c
@@ -2,6 +2,7 @@
 #include "furi_hal_nfc_tech_i.h"
 
 #include <digital_signal/presets/nfc/iso15693_signal.h>
+#include <nfc/protocols/iso15693_3/iso15693_3.h>
 #include <signal_reader/parsers/iso15693/iso15693_parser.h>
 
 #include <furi_hal_resources.h>
@@ -31,6 +32,7 @@
 typedef struct {
     Iso15693Signal* signal;
     Iso15693Parser* parser;
+    Iso15693SignalDataRate response_data_rate;
 } FuriHalNfcIso15693Listener;
 
 typedef struct {
@@ -50,6 +52,7 @@ static FuriHalNfcIso15693Listener* furi_hal_nfc_iso15693_listener_alloc(void) {
     instance->signal = iso15693_signal_alloc(&gpio_spi_r_mosi);
     instance->parser =
         iso15693_parser_alloc(&gpio_nfc_irq_rfid_pull, FURI_HAL_NFC_ISO15693_MAX_FRAME_SIZE);
+    instance->response_data_rate = Iso15693SignalDataRateHi;
 
     return instance;
 }
@@ -345,7 +348,10 @@ static FuriHalNfcError furi_hal_nfc_iso15693_listener_deinit(const FuriHalSpiBus
 static FuriHalNfcError
     furi_hal_nfc_iso15693_listener_tx_transparent(const uint8_t* data, size_t data_size) {
     iso15693_signal_tx(
-        furi_hal_nfc_iso15693_listener->signal, Iso15693SignalDataRateHi, data, data_size);
+        furi_hal_nfc_iso15693_listener->signal,
+        furi_hal_nfc_iso15693_listener->response_data_rate,
+        data,
+        data_size);
 
     return FuriHalNfcErrorNone;
 }
@@ -404,7 +410,9 @@ static FuriHalNfcError furi_hal_nfc_iso15693_listener_tx(
 }
 
 FuriHalNfcError furi_hal_nfc_iso15693_listener_tx_sof(void) {
-    iso15693_signal_tx_sof(furi_hal_nfc_iso15693_listener->signal, Iso15693SignalDataRateHi);
+    iso15693_signal_tx_sof(
+        furi_hal_nfc_iso15693_listener->signal,
+        furi_hal_nfc_iso15693_listener->response_data_rate);
 
     return FuriHalNfcErrorNone;
 }
@@ -424,6 +432,13 @@ static FuriHalNfcError furi_hal_nfc_iso15693_listener_rx(
 
     iso15693_parser_get_data(
         furi_hal_nfc_iso15693_listener->parser, rx_data, rx_data_size, rx_bits);
+
+    if(*rx_bits >= BITS_IN_BYTE) {
+        const uint8_t flags = rx_data[0];
+        furi_hal_nfc_iso15693_listener->response_data_rate =
+            (flags & ISO15693_3_REQ_FLAG_DATA_RATE_HI) ? Iso15693SignalDataRateHi :
+                                                         Iso15693SignalDataRateLo;
+    }
 
     return FuriHalNfcErrorNone;
 }

--- a/targets/f7/furi_hal/furi_hal_nfc_timer.c
+++ b/targets/f7/furi_hal/furi_hal_nfc_timer.c
@@ -6,6 +6,7 @@
 #include <furi_hal_interrupt.h>
 #include <furi_hal_resources.h>
 #include <furi_hal_bus.h>
+#include <momentum/momentum.h>
 
 #define TAG "FuriHalNfcTimer"
 
@@ -123,7 +124,13 @@ static int32_t furi_hal_nfc_timer_get_compensation(FuriHalNfcTimer timer) {
 
     } else if(furi_hal_nfc.mode == FuriHalNfcModeListener) {
         const FuriHalNfcListenerCompensation* comp = &current_tech->listener.compensation;
-        if(timer == FuriHalNfcTimerBlockTx) return comp->fdt;
+        if(timer == FuriHalNfcTimerBlockTx) {
+            if((furi_hal_nfc.tech == FuriHalNfcTechIso15693) &&
+               momentum_settings.nfcv_fast_timing) {
+                return INT32_MAX;
+            }
+            return comp->fdt;
+        }
     }
 
     return 0;


### PR DESCRIPTION
## Summary

This improves NFC-V / ISO15693 listener behavior, especially for emulation and SLIX cards.

The change fixes listener response timing, adds support for selecting the response data rate from the reader request flags, improves ISO15693 inventory mask handling, and adds proper 16-slot inventory EOF flow handling. It also exposes more listener events so the NFC app can log received frames, CRC errors, transmitted responses, and field on/off transitions during emulation.

## Changes

- Fix ISO15693 listener responses to use the data rate requested by the reader instead of always replying at high data rate.
- Add NFC-V fast listener timing support through the existing Momentum setting.
- Implement ISO15693 inventory mask matching against the UID bits.
- Implement 16-slot inventory handling by delaying the response until the matching EOF slot.
- Reset inventory/session state correctly when a new request or field-off event is received.
- Add ISO15693 listener events for:
  - field on
  - field off
  - valid request
  - request with CRC/error
  - transmitted response
- Forward the new ISO15693 events through the SLIX listener.
- Improve NFC app emulate logging for ISO15693 and SLIX:
  - `FIELD ON`
  - `FIELD OFF`
  - `R:` received request
  - `E:` received invalid/error frame
  - `T:` transmitted response
- Extend ISO15693 signal generation internals to prepare both single-subcarrier and dual-subcarrier frame banks.

## Testing

- Verified the patch with `git diff --check`.
- Verified the generated patch applies cleanly on top of the upstream `dev` base commit.