### PR TITLE
NFC: Bound card-controlled TLV lengths in the EMV poller

### DIFF
--- a/lib/nfc/protocols/emv/emv.h
+++ b/lib/nfc/protocols/emv/emv.h
@@ -86,7 +86,8 @@ typedef struct {
     uint8_t application_interchange_profile[2];
     char application_name[16 + 1];
     char application_label[16 + 1];
-    char cardholder_name[24 + 1];
+    // EMV Book 3 Annex A gives 5F20 an ans length of 2-26
+    char cardholder_name[26 + 1];
     uint8_t pan[10]; // card_number
     uint8_t pan_len;
     uint8_t exp_day;

--- a/lib/nfc/protocols/emv/emv.h
+++ b/lib/nfc/protocols/emv/emv.h
@@ -54,6 +54,7 @@ extern "C" {
 
 typedef struct {
     uint16_t tag;
+    uint8_t size;
     uint8_t data[];
 } PDOLValue;
 

--- a/lib/nfc/protocols/emv/emv_poller_i.c
+++ b/lib/nfc/protocols/emv/emv_poller_i.c
@@ -84,7 +84,7 @@ static bool
 
     switch(tag) {
     case EMV_TAG_LOG_FMT:
-        furi_check(tlen < sizeof(app->log_fmt));
+        if(tlen > sizeof(app->log_fmt)) break;
         memcpy(app->log_fmt, &buff[i], tlen);
         app->log_fmt_len = tlen;
         success = true;
@@ -92,15 +92,16 @@ static bool
         break;
     case EMV_TAG_GPO_FMT1:
         // skip AIP
+        if(tlen < 2) break;
         i += 2;
         tlen -= 2;
-        furi_check(tlen < sizeof(app->afl.data));
         memcpy(app->afl.data, &buff[i], tlen);
         app->afl.size = tlen;
         success = true;
         FURI_LOG_T(TAG, "found EMV_TAG_GPO_FMT1 %X: ", tag);
         break;
     case EMV_TAG_AID:
+        if(tlen > sizeof(app->aid)) break;
         app->aid_len = tlen;
         memcpy(app->aid, &buff[i], tlen);
         success = true;
@@ -116,7 +117,7 @@ static bool
         FURI_LOG_T(TAG, "found EMV_TAG_APP_PRIORITY %X: %d", tag, app->priority);
         break;
     case EMV_TAG_APPL_INTERCHANGE_PROFILE:
-        furi_check(tlen == 2);
+        if(tlen != sizeof(app->application_interchange_profile)) break;
         memcpy(app->application_interchange_profile, &buff[i], tlen);
         success = true;
         FURI_LOG_T(TAG, "found EMV_TAG_APPL_INTERCHANGE_PROFILE %x: ", tag);
@@ -126,13 +127,14 @@ static bool
         FURI_LOG_RAW_T("\r\n");
         break;
     case EMV_TAG_APPL_LABEL:
+        if(tlen >= sizeof(app->application_label)) break;
         memcpy(app->application_label, &buff[i], tlen);
         app->application_label[tlen] = '\0';
         success = true;
         FURI_LOG_T(TAG, "found EMV_TAG_APPL_LABEL %x: %s", tag, app->application_label);
         break;
     case EMV_TAG_APPL_NAME:
-        furi_check(tlen < sizeof(app->application_name));
+        if(tlen >= sizeof(app->application_name)) break;
         memcpy(app->application_name, &buff[i], tlen);
         app->application_name[tlen] = '\0';
         success = true;
@@ -161,6 +163,7 @@ static bool
     case EMV_TAG_TRACK_1_EQUIV: {
         // Contain PAN and expire date
         char track_1_equiv[80];
+        if(tlen >= sizeof(track_1_equiv)) break;
         memcpy(track_1_equiv, &buff[i], tlen);
         track_1_equiv[tlen] = '\0';
         success = true;
@@ -170,8 +173,9 @@ static bool
     case EMV_TAG_TRACK_2_DATA:
     case EMV_TAG_TRACK_2_EQUIV: {
         FURI_LOG_T(TAG, "found EMV_TAG_TRACK_2 %X", tag);
-        // 0xD0 delimits PAN from expiry (YYMM)
-        for(int x = 1; x < tlen; x++) {
+        // 0xD0 delimits PAN from expiry (YYMM). The delimiter is followed by two
+        // more value bytes, and the PAN cannot be longer than the field holding it.
+        for(int x = 1; x + 3 < tlen && x < (int)sizeof(app->pan); x++) {
             if(buff[i + x + 1] > 0xD0) {
                 memcpy(app->pan, &buff[i], x + 1);
                 app->pan_len = x + 1;
@@ -184,7 +188,9 @@ static bool
         // Convert 4-bit to ASCII representation
         char track_2_equiv[41];
         uint8_t track_2_equiv_len = 0;
-        for(int x = 0; x < tlen; x++) {
+        // Each value byte expands to two characters, and one byte is kept for the
+        // terminator written after the loop.
+        for(int x = 0; x < tlen && (size_t)(x * 2 + 2) < sizeof(track_2_equiv); x++) {
             char top = (buff[i + x] >> 4) + '0';
             char bottom = (buff[i + x] & 0x0F) + '0';
             track_2_equiv[x * 2] = top;
@@ -200,7 +206,8 @@ static bool
         break;
     }
     case EMV_TAG_CARDHOLDER_NAME: {
-        if(strlen(app->cardholder_name) > tlen) break;
+        // The previous contents' length says nothing about how much room is left.
+        if(tlen >= sizeof(app->cardholder_name)) break;
         memcpy(app->cardholder_name, &buff[i], tlen);
         app->cardholder_name[tlen] = '\0';
 
@@ -216,6 +223,7 @@ static bool
         break;
     }
     case EMV_TAG_PAN:
+        if(tlen > sizeof(app->pan)) break;
         memcpy(app->pan, &buff[i], tlen);
         app->pan_len = tlen;
         success = true;
@@ -261,6 +269,7 @@ static bool
         success = true;
         break;
     case EMV_TAG_LOG_AMOUNT:
+        if(tlen > sizeof(app->trans[app->active_tr].amount)) break;
         memcpy(&app->trans[app->active_tr].amount, &buff[i], tlen);
         success = true;
         break;
@@ -273,10 +282,12 @@ static bool
         success = true;
         break;
     case EMV_TAG_LOG_DATE:
+        if(tlen > sizeof(app->trans[app->active_tr].date)) break;
         memcpy(&app->trans[app->active_tr].date, &buff[i], tlen);
         success = true;
         break;
     case EMV_TAG_LOG_TIME:
+        if(tlen > sizeof(app->trans[app->active_tr].time)) break;
         memcpy(&app->trans[app->active_tr].time, &buff[i], tlen);
         success = true;
         break;
@@ -323,11 +334,16 @@ static bool
     uint8_t tlen = 0;
     bool success = false;
 
+    // Every byte read below comes from the card, so the header has to be
+    // checked against the response length before it is dereferenced.
+    if(i >= len) return success;
+
     first_byte = buff[i];
 
     if(emv_response_error(buff, len)) return success;
 
     if((first_byte & 31) == 31) { // 2-byte tag
+        if(i + 1 >= len) return success;
         tag = buff[i] << 8 | buff[i + 1];
         i++;
         FURI_LOG_T(TAG, " 2-byte TLV EMV tag: %x", tag);
@@ -336,15 +352,23 @@ static bool
         FURI_LOG_T(TAG, " 1-byte TLV EMV tag: %x", tag);
     }
     i++;
+    if(i >= len) return success;
     tlen = buff[i];
     if((tlen & 128) == 128) { // long length value
         i++;
+        if(i >= len) return success;
         tlen = buff[i];
         FURI_LOG_T(TAG, " 2-byte TLV length: %d", tlen);
     } else {
         FURI_LOG_T(TAG, " 1-byte TLV length: %d", tlen);
     }
     i++;
+
+    // A tag may not claim more value bytes than the card actually sent.
+    if((uint16_t)i + tlen > len) {
+        FURI_LOG_T(TAG, " TLV length %d overruns response length %d", tlen, len);
+        return success;
+    }
 
     *off = i;
     *t = tag;
@@ -783,9 +807,13 @@ EmvError emv_poller_read_log_entry(EmvPoller* instance) {
         }
 
         instance->data->emv_application.active_tr++;
-        furi_check(
-            instance->data->emv_application.active_tr <
-            COUNT_OF(instance->data->emv_application.trans));
+        // The record count comes from the card, so stop at the end of the array
+        // instead of panicking on a card that advertises more records than fit.
+        if(instance->data->emv_application.active_tr >=
+           COUNT_OF(instance->data->emv_application.trans)) {
+            FURI_LOG_D(TAG, "Transaction log full, ignoring the remaining records");
+            break;
+        }
     }
 
     instance->data->emv_application.saving_trans_list = false;

--- a/lib/nfc/protocols/emv/emv_poller_i.c
+++ b/lib/nfc/protocols/emv/emv_poller_i.c
@@ -225,6 +225,8 @@ static bool
     case EMV_TAG_CARDHOLDER_NAME: {
         // The previous contents' length says nothing about how much room is left.
         if(tlen >= sizeof(app->cardholder_name)) break;
+        // A bruteforced read sees 5F20 in several records; keep the longest
+        if(strlen(app->cardholder_name) > tlen) break;
         memcpy(app->cardholder_name, &buff[i], tlen);
         app->cardholder_name[tlen] = '\0';
 

--- a/lib/nfc/protocols/emv/emv_poller_i.c
+++ b/lib/nfc/protocols/emv/emv_poller_i.c
@@ -3,30 +3,41 @@
 
 #define TAG "EMVPoller"
 
+// 256 B ISO14443-4 poller buffer, less 1 PCB + 4 header + Lc + 83 + len + Le
+#define EMV_PDOL_MAX_SIZE (256U - 9U)
+
 // "Terminal" parameters, which could be requested by card
-const PDOLValue pdol_term_info = {0x9F59, {0xC8, 0x80, 0x00}}; // Terminal transaction information
-const PDOLValue pdol_term_type = {0x9F5A, {0x00}}; // Terminal transaction type
-const PDOLValue pdol_merchant_type = {0x9F58, {0x01}}; // Merchant type indicator
+const PDOLValue pdol_term_info = {
+    0x9F59,
+    3,
+    {0xC8, 0x80, 0x00}}; // Terminal transaction information
+const PDOLValue pdol_term_type = {0x9F5A, 1, {0x00}}; // Terminal transaction type
+const PDOLValue pdol_merchant_type = {0x9F58, 1, {0x01}}; // Merchant type indicator
 const PDOLValue pdol_term_trans_qualifies = {
     0x9F66,
+    4,
     {0x79, 0x00, 0x40, 0x80}}; // Terminal transaction qualifiers
-const PDOLValue pdol_addtnl_term_qualifies = {
-    0x9F40,
-    {0x79, 0x00, 0x40, 0x80}}; // Terminal transaction qualifiers
+// EMV gives 9F40 five bytes; the terminal holds four, so the fifth is zero-filled
+const PDOLValue pdol_addtnl_term_qualifies = {0x9F40, 4, {0x79, 0x00, 0x40, 0x80}};
 const PDOLValue pdol_amount_authorise = {
     0x9F02,
+    6,
     {0x00, 0x00, 0x00, 0x10, 0x00, 0x00}}; // Amount, authorised
-const PDOLValue pdol_amount = {0x9F03, {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}; // Amount
-const PDOLValue pdol_country_code = {0x9F1A, {0x01, 0x24}}; // Terminal country code
-const PDOLValue pdol_currency_code = {0x5F2A, {0x01, 0x24}}; // Transaction currency code
+const PDOLValue pdol_amount = {0x9F03, 6, {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}}; // Amount
+const PDOLValue pdol_country_code = {0x9F1A, 2, {0x01, 0x24}}; // Terminal country code
+const PDOLValue pdol_currency_code = {0x5F2A, 2, {0x01, 0x24}}; // Transaction currency code
 const PDOLValue pdol_term_verification = {
     0x95,
+    5,
     {0x00, 0x00, 0x00, 0x00, 0x00}}; // Terminal verification results
-const PDOLValue pdol_transaction_date = {0x9A, {0x19, 0x01, 0x01}}; // Transaction date
-const PDOLValue pdol_transaction_type = {0x9C, {0x00}}; // Transaction type
-const PDOLValue pdol_transaction_cert = {0x98, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                                0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}; // Transaction cert
-const PDOLValue pdol_unpredict_number = {0x9F37, {0x82, 0x3D, 0xDE, 0x7A}}; // Unpredictable number
+const PDOLValue pdol_transaction_date = {0x9A, 3, {0x19, 0x01, 0x01}}; // Transaction date
+const PDOLValue pdol_transaction_type = {0x9C, 1, {0x00}}; // Transaction type
+const PDOLValue pdol_transaction_cert = {0x98, 20, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                    0, 0, 0, 0, 0, 0, 0, 0, 0}}; // Transaction cert
+const PDOLValue pdol_unpredict_number = {
+    0x9F37,
+    4,
+    {0x82, 0x3D, 0xDE, 0x7A}}; // Unpredictable number
 
 const PDOLValue* const pdol_values[] = {
     &pdol_term_info,
@@ -448,10 +459,18 @@ static void emv_prepare_pdol(APDU* dest, APDU* src) {
             return;
         }
 
-        furi_check(dest->size + tlen < sizeof(dest->data));
+        // The GPO is re-encoded into the ISO14443-4 poller buffer, the narrower of the two
+        if((uint16_t)dest->size + tlen > EMV_PDOL_MAX_SIZE) {
+            dest->size = 0;
+            return;
+        }
+
         for(uint8_t j = 0; j < COUNT_OF(pdol_values); j++) {
             if(tag == pdol_values[j]->tag) {
-                memcpy(dest->data + dest->size, pdol_values[j]->data, tlen);
+                // The card names the length it wants, which is not what the terminal holds
+                uint8_t copy_len = MIN(tlen, pdol_values[j]->size);
+                memcpy(dest->data + dest->size, pdol_values[j]->data, copy_len);
+                memset(dest->data + dest->size + copy_len, 0, tlen - copy_len);
                 dest->size += tlen;
                 tag_found = true;
                 break;

--- a/lib/nfc/protocols/emv/emv_poller_i.c
+++ b/lib/nfc/protocols/emv/emv_poller_i.c
@@ -77,6 +77,11 @@ static void emv_trace(EmvPoller* instance, const char* message) {
     }
 }
 
+// active_tr is driven by the card, so it can end up one past the end of trans[]
+static bool emv_trans_writable(const EmvApplication* app) {
+    return app->saving_trans_list && app->active_tr < COUNT_OF(app->trans);
+}
+
 static bool
     emv_decode_tlv_tag(const uint8_t* buff, uint16_t tag, uint8_t tlen, EmvApplication* app) {
     uint8_t i = 0;
@@ -112,6 +117,7 @@ static bool
         FURI_LOG_RAW_T("\r\n");
         break;
     case EMV_TAG_PRIORITY:
+        if(tlen != sizeof(app->priority)) break;
         memcpy(&app->priority, &buff[i], tlen);
         success = true;
         FURI_LOG_T(TAG, "found EMV_TAG_APP_PRIORITY %X: %d", tag, app->priority);
@@ -262,32 +268,34 @@ static bool
         success = true;
         break;
     case EMV_TAG_ATC:
-        if(app->saving_trans_list)
+        if(emv_trans_writable(app))
             app->trans[app->active_tr].atc = (buff[i] << 8 | buff[i + 1]);
         else
             app->transaction_counter = (buff[i] << 8 | buff[i + 1]);
         success = true;
         break;
     case EMV_TAG_LOG_AMOUNT:
-        if(tlen > sizeof(app->trans[app->active_tr].amount)) break;
+        if(!emv_trans_writable(app) || tlen > sizeof(app->trans[app->active_tr].amount)) break;
         memcpy(&app->trans[app->active_tr].amount, &buff[i], tlen);
         success = true;
         break;
     case EMV_TAG_LOG_COUNTRY:
+        if(!emv_trans_writable(app)) break;
         app->trans[app->active_tr].country = (buff[i] << 8 | buff[i + 1]);
         success = true;
         break;
     case EMV_TAG_LOG_CURRENCY:
+        if(!emv_trans_writable(app)) break;
         app->trans[app->active_tr].currency = (buff[i] << 8 | buff[i + 1]);
         success = true;
         break;
     case EMV_TAG_LOG_DATE:
-        if(tlen > sizeof(app->trans[app->active_tr].date)) break;
+        if(!emv_trans_writable(app) || tlen > sizeof(app->trans[app->active_tr].date)) break;
         memcpy(&app->trans[app->active_tr].date, &buff[i], tlen);
         success = true;
         break;
     case EMV_TAG_LOG_TIME:
-        if(tlen > sizeof(app->trans[app->active_tr].time)) break;
+        if(!emv_trans_writable(app) || tlen > sizeof(app->trans[app->active_tr].time)) break;
         memcpy(&app->trans[app->active_tr].time, &buff[i], tlen);
         success = true;
         break;
@@ -364,12 +372,6 @@ static bool
     }
     i++;
 
-    // A tag may not claim more value bytes than the card actually sent.
-    if((uint16_t)i + tlen > len) {
-        FURI_LOG_T(TAG, " TLV length %d overruns response length %d", tlen, len);
-        return success;
-    }
-
     *off = i;
     *t = tag;
     *tl = tlen;
@@ -394,10 +396,11 @@ static bool emv_decode_tl(
     while(f < fmt_len && i < len) {
         success = emv_parse_tag(fmt, fmt_len, &tag, &tlen, &f);
         if(!success) return success;
+        // The format only names tags and lengths; the values live in the record
+        if((uint16_t)i + tlen > len) return false;
         emv_decode_tlv_tag(&buff[i], tag, tlen, app);
         i += tlen;
     }
-    success = true;
     return success;
 }
 
@@ -413,6 +416,9 @@ static bool emv_decode_response_tlv(const uint8_t* buff, uint8_t len, EmvApplica
 
         success = emv_parse_tag(buff, len, &tag, &tlen, &i);
         if(!success) return success;
+
+        // A tag may not claim more value bytes than the card actually sent
+        if((uint16_t)i + tlen > len) return false;
 
         if((first_byte & 32) == 32) { // "Constructed" -- contains more TLV data to parse
             FURI_LOG_T(TAG, "Constructed TLV %x", tag);

--- a/lib/nfc/protocols/emv/emv_poller_i.c
+++ b/lib/nfc/protocols/emv/emv_poller_i.c
@@ -88,6 +88,12 @@ static void emv_trace(EmvPoller* instance, const char* message) {
     }
 }
 
+// FURI_LOG_T and FURI_LOG_D are compiled out in release builds, so rejections use _W
+static bool emv_tag_rejected(uint16_t tag, uint8_t tlen) {
+    FURI_LOG_W(TAG, "Rejected tag %04X of length %d", tag, tlen);
+    return false;
+}
+
 // active_tr is driven by the card, so it can end up one past the end of trans[]
 static bool emv_trans_writable(const EmvApplication* app) {
     return app->saving_trans_list && app->active_tr < COUNT_OF(app->trans);
@@ -100,7 +106,7 @@ static bool
 
     switch(tag) {
     case EMV_TAG_LOG_FMT:
-        if(tlen > sizeof(app->log_fmt)) break;
+        if(tlen > sizeof(app->log_fmt)) return emv_tag_rejected(tag, tlen);
         memcpy(app->log_fmt, &buff[i], tlen);
         app->log_fmt_len = tlen;
         success = true;
@@ -108,7 +114,7 @@ static bool
         break;
     case EMV_TAG_GPO_FMT1:
         // skip AIP
-        if(tlen < 2) break;
+        if(tlen < 2) return emv_tag_rejected(tag, tlen);
         i += 2;
         tlen -= 2;
         memcpy(app->afl.data, &buff[i], tlen);
@@ -117,7 +123,7 @@ static bool
         FURI_LOG_T(TAG, "found EMV_TAG_GPO_FMT1 %X: ", tag);
         break;
     case EMV_TAG_AID:
-        if(tlen > sizeof(app->aid)) break;
+        if(tlen > sizeof(app->aid)) return emv_tag_rejected(tag, tlen);
         app->aid_len = tlen;
         memcpy(app->aid, &buff[i], tlen);
         success = true;
@@ -128,13 +134,14 @@ static bool
         FURI_LOG_RAW_T("\r\n");
         break;
     case EMV_TAG_PRIORITY:
-        if(tlen != sizeof(app->priority)) break;
+        if(tlen != sizeof(app->priority)) return emv_tag_rejected(tag, tlen);
         memcpy(&app->priority, &buff[i], tlen);
         success = true;
         FURI_LOG_T(TAG, "found EMV_TAG_APP_PRIORITY %X: %d", tag, app->priority);
         break;
     case EMV_TAG_APPL_INTERCHANGE_PROFILE:
-        if(tlen != sizeof(app->application_interchange_profile)) break;
+        if(tlen != sizeof(app->application_interchange_profile))
+            return emv_tag_rejected(tag, tlen);
         memcpy(app->application_interchange_profile, &buff[i], tlen);
         success = true;
         FURI_LOG_T(TAG, "found EMV_TAG_APPL_INTERCHANGE_PROFILE %x: ", tag);
@@ -144,14 +151,14 @@ static bool
         FURI_LOG_RAW_T("\r\n");
         break;
     case EMV_TAG_APPL_LABEL:
-        if(tlen >= sizeof(app->application_label)) break;
+        if(tlen >= sizeof(app->application_label)) return emv_tag_rejected(tag, tlen);
         memcpy(app->application_label, &buff[i], tlen);
         app->application_label[tlen] = '\0';
         success = true;
         FURI_LOG_T(TAG, "found EMV_TAG_APPL_LABEL %x: %s", tag, app->application_label);
         break;
     case EMV_TAG_APPL_NAME:
-        if(tlen >= sizeof(app->application_name)) break;
+        if(tlen >= sizeof(app->application_name)) return emv_tag_rejected(tag, tlen);
         memcpy(app->application_name, &buff[i], tlen);
         app->application_name[tlen] = '\0';
         success = true;
@@ -180,7 +187,7 @@ static bool
     case EMV_TAG_TRACK_1_EQUIV: {
         // Contain PAN and expire date
         char track_1_equiv[80];
-        if(tlen >= sizeof(track_1_equiv)) break;
+        if(tlen >= sizeof(track_1_equiv)) return emv_tag_rejected(tag, tlen);
         memcpy(track_1_equiv, &buff[i], tlen);
         track_1_equiv[tlen] = '\0';
         success = true;
@@ -224,7 +231,7 @@ static bool
     }
     case EMV_TAG_CARDHOLDER_NAME: {
         // The previous contents' length says nothing about how much room is left.
-        if(tlen >= sizeof(app->cardholder_name)) break;
+        if(tlen >= sizeof(app->cardholder_name)) return emv_tag_rejected(tag, tlen);
         // A bruteforced read sees 5F20 in several records; keep the longest
         if(strlen(app->cardholder_name) > tlen) break;
         memcpy(app->cardholder_name, &buff[i], tlen);
@@ -242,7 +249,7 @@ static bool
         break;
     }
     case EMV_TAG_PAN:
-        if(tlen > sizeof(app->pan)) break;
+        if(tlen > sizeof(app->pan)) return emv_tag_rejected(tag, tlen);
         memcpy(app->pan, &buff[i], tlen);
         app->pan_len = tlen;
         success = true;
@@ -288,27 +295,30 @@ static bool
         success = true;
         break;
     case EMV_TAG_LOG_AMOUNT:
-        if(!emv_trans_writable(app) || tlen > sizeof(app->trans[app->active_tr].amount)) break;
+        if(!emv_trans_writable(app) || tlen > sizeof(app->trans[app->active_tr].amount))
+            return emv_tag_rejected(tag, tlen);
         memcpy(&app->trans[app->active_tr].amount, &buff[i], tlen);
         success = true;
         break;
     case EMV_TAG_LOG_COUNTRY:
-        if(!emv_trans_writable(app)) break;
+        if(!emv_trans_writable(app)) return emv_tag_rejected(tag, tlen);
         app->trans[app->active_tr].country = (buff[i] << 8 | buff[i + 1]);
         success = true;
         break;
     case EMV_TAG_LOG_CURRENCY:
-        if(!emv_trans_writable(app)) break;
+        if(!emv_trans_writable(app)) return emv_tag_rejected(tag, tlen);
         app->trans[app->active_tr].currency = (buff[i] << 8 | buff[i + 1]);
         success = true;
         break;
     case EMV_TAG_LOG_DATE:
-        if(!emv_trans_writable(app) || tlen > sizeof(app->trans[app->active_tr].date)) break;
+        if(!emv_trans_writable(app) || tlen > sizeof(app->trans[app->active_tr].date))
+            return emv_tag_rejected(tag, tlen);
         memcpy(&app->trans[app->active_tr].date, &buff[i], tlen);
         success = true;
         break;
     case EMV_TAG_LOG_TIME:
-        if(!emv_trans_writable(app) || tlen > sizeof(app->trans[app->active_tr].time)) break;
+        if(!emv_trans_writable(app) || tlen > sizeof(app->trans[app->active_tr].time))
+            return emv_tag_rejected(tag, tlen);
         memcpy(&app->trans[app->active_tr].time, &buff[i], tlen);
         success = true;
         break;
@@ -410,7 +420,11 @@ static bool emv_decode_tl(
         success = emv_parse_tag(fmt, fmt_len, &tag, &tlen, &f);
         if(!success) return success;
         // The format only names tags and lengths; the values live in the record
-        if((uint16_t)i + tlen > len) return false;
+        if((uint16_t)i + tlen > len) {
+            FURI_LOG_W(
+                TAG, "Log record too short for tag %04X: %d bytes at %d of %d", tag, tlen, i, len);
+            return false;
+        }
         emv_decode_tlv_tag(&buff[i], tag, tlen, app);
         i += tlen;
     }
@@ -431,7 +445,7 @@ static bool emv_decode_response_tlv(const uint8_t* buff, uint8_t len, EmvApplica
         if(!success) return success;
 
         // A tag may not claim more value bytes than the card actually sent
-        if((uint16_t)i + tlen > len) return false;
+        if((uint16_t)i + tlen > len) return emv_tag_rejected(tag, tlen);
 
         if((first_byte & 32) == 32) { // "Constructed" -- contains more TLV data to parse
             FURI_LOG_T(TAG, "Constructed TLV %x", tag);
@@ -456,13 +470,14 @@ static void emv_prepare_pdol(APDU* dest, APDU* src) {
     while(i < src->size) {
         bool tag_found = false;
         if(!emv_parse_tag(src->data, src->size, &tag, &tlen, &i)) {
-            FURI_LOG_T(TAG, "Parsing PDOL failed at 0x%x", i);
+            FURI_LOG_W(TAG, "Parsing PDOL failed at 0x%x", i);
             dest->size = 0;
             return;
         }
 
         // The GPO is re-encoded into the ISO14443-4 poller buffer, the narrower of the two
         if((uint16_t)dest->size + tlen > EMV_PDOL_MAX_SIZE) {
+            emv_tag_rejected(tag, tlen);
             dest->size = 0;
             return;
         }


### PR DESCRIPTION
## Description

`emv_parse_tag()` takes each TLV length straight off the card and passes it through unvalidated:

```c
tlen = buff[i];
if((tlen & 128) == 128) { // long length value
    i++;
    tlen = buff[i];       // next byte verbatim
}
...
*tl = tlen;
```

`emv_decode_tlv_tag()` then uses that value as the size of a `memcpy` into fixed-size fields. Four tags are guarded with `furi_check(tlen < sizeof(...))`; the rest are not guarded at all. `len` is `bit_buffer_get_size_bytes(instance->rx_buffer)` and `emv_response_error()` only rejects a 2-byte status word, so any longer response is parsed. No file needs to be loaded — tapping a card that returns a crafted response is enough.

| crafted response | destination | size | writes |
|---|---|---|---|
| `5A 20` + 32 B | `app->pan` | 10 | 32 |
| `4F 40` + 64 B | `app->aid` | 16 | 64 |
| `57 30` + 48 B | `track_2_equiv` (stack) | 41 | 97 |
| `57 30` + 48 B | `app->pan` | 10 | 48 |
| `5F 20 60` + 96 B | `app->cardholder_name` | 25 | 97 |
| `5A 81 FF` + … | `app->pan` | 10 | 255 |

`track_2_equiv` is the worst: the conversion loop writes `track_2_equiv[x * 2]` and `[x * 2 + 1]` for `x < tlen`, so a 48-byte value writes ~97 bytes into a 41-byte stack buffer. In this repo that block is **not** behind `#ifndef LOGS_RELEASE_BUILD`, so it applies to `COMPACT` release builds as well.

Also in the same file:

- `EMV_TAG_GPO_FMT1` does `tlen -= 2` on a `uint8_t` without checking `tlen >= 2`, underflowing to ~254.
- `EMV_TAG_CARDHOLDER_NAME`'s guard is `if(strlen(app->cardholder_name) > tlen) break;`, which compares the *previous* contents' length and bounds nothing.
- `EMV_TAG_TRACK_2_*` reads `buff[i + x + 2]` and `buff[i + x + 3]`, up to three bytes past the value.
- `emv_parse_tag` dereferences `buff[i]` and `buff[i + 1]` before `i` is bounded by `len`.
- `emv_poller_read_log_entry` increments `active_tr` and then `furi_check`s it, so a card advertising more log records than `trans[]` holds panics the device.

## Fix

Reject cleanly rather than panic, since all of this is attacker-controlled input:

- `emv_parse_tag` bounds `i` against `len` before every read, and rejects a tag whose value overruns the response (`i + tlen > len`).
- Every copy into a fixed-size field is bounded. An over-long field `break`s out of its `case`, so the tag is skipped and the rest of the card still parses.
- The four existing `furi_check`s became the same graceful reject — panicking on a malformed card turns memory corruption into a remote crash, which is the same class of bug.
- The `track_2_equiv` loop is bounded to the buffer, and the PAN scan to `sizeof(app->pan)` plus the three bytes it reads ahead.
- The `active_tr` `furi_check` became a loop break.

Not added: bounds for `EMV_TAG_PDOL` and `EMV_TAG_AFL`. Both destinations are `APDU.data[MAX_APDU_LEN]`, i.e. 255 bytes, and `tlen` is a `uint8_t`, so a check there is provably always false and would only add dead code.

## Verification

`./fbt firmware_all` builds clean (`f7-firmware-C`, `API version 87.1 is up to date`).

Context: this is the same change as DarkFlippers/unleashed-firmware#1048, adapted to this tree. #553 here asked about a private channel for an EMV overflow in the `.nfc` loading path and was told public handling is fine and a PR would be welcome; that reporter never opened one.

## Follow-up, deliberately not in this PR

`emv_prepare_pdol()` copies `tlen` bytes out of `pdol_values[j]->data`, where `tlen` is the length the *card requests* and those constants are as small as one byte (`pdol_term_type = {0x9F5A, {0x00}}`). A card asking for that tag with `tlen = 200` reads 200 bytes of `.rodata` and transmits them back to the card. Fixing it properly needs a length recorded on `PDOLValue` (its `data` is a flexible array member, so there is no `sizeof` to bound with), which is a bigger and more opinionated change — separate PR, happy to open it if you want it.