### PR TITLE
NFC: Fix Type 4 Tag writes that start inside the NLEN field

### DIFF
--- a/lib/nfc/protocols/type_4_tag/type_4_tag_listener.c
+++ b/lib/nfc/protocols/type_4_tag/type_4_tag_listener.c
@@ -54,7 +54,7 @@ static const Type4TagData* type_4_tag_listener_get_data(Type4TagListener* instan
 
 static NfcCommand type_4_tag_listener_run(NfcGenericEvent event, void* context) {
     furi_assert(context);
-    furi_assert(event.protocol == NfcProtocolIso15693_3);
+    furi_assert(event.protocol == NfcProtocolIso14443_4a);
     furi_assert(event.event_data);
 
     Type4TagListener* instance = context;

--- a/lib/nfc/protocols/type_4_tag/type_4_tag_listener_i.c
+++ b/lib/nfc/protocols/type_4_tag/type_4_tag_listener_i.c
@@ -196,9 +196,20 @@ static Type4TagError type_4_tag_listener_iso_write(
     }
 
     if(instance->state == Type4TagListenerStateSelectedNdefMessage) {
-        if(offset + lc > sizeof(uint16_t) + (instance->data->is_tag_specific ?
-                                                 instance->data->ndef_max_len :
-                                                 TYPE_4_TAG_DEFAULT_NDEF_SIZE)) {
+        const size_t ndef_max_len = instance->data->is_tag_specific ?
+                                        instance->data->ndef_max_len :
+                                        TYPE_4_TAG_DEFAULT_NDEF_SIZE;
+
+        // An APDU without a data field arrives here as data == NULL
+        if(lc == 0) {
+            bit_buffer_append_bytes(
+                instance->tx_buffer,
+                type_4_tag_bad_params_apdu,
+                sizeof(type_4_tag_bad_params_apdu));
+            return Type4TagErrorWrongFormat;
+        }
+
+        if(offset + lc > sizeof(uint16_t) + ndef_max_len) {
             bit_buffer_append_bytes(
                 instance->tx_buffer,
                 type_4_tag_offset_error_apdu,
@@ -208,18 +219,30 @@ static Type4TagError type_4_tag_listener_iso_write(
 
         const size_t ndef_file_len = simple_array_get_count(instance->data->ndef_data);
         size_t ndef_file_len_new = ndef_file_len;
+        // A write can cover only part of the 2-byte NLEN header, so merge instead of replacing
         if(offset < sizeof(uint16_t)) {
-            const uint8_t write_len = sizeof(uint16_t) - offset;
-            ndef_file_len_new = bit_lib_bytes_to_num_be(data, write_len);
+            uint8_t ndef_file_len_be[sizeof(uint16_t)];
+            bit_lib_num_to_bytes_be(ndef_file_len, sizeof(ndef_file_len_be), ndef_file_len_be);
+            const uint8_t write_len = MIN(sizeof(ndef_file_len_be) - offset, lc);
+            memcpy(&ndef_file_len_be[offset], data, write_len);
+            ndef_file_len_new =
+                bit_lib_bytes_to_num_be(ndef_file_len_be, sizeof(ndef_file_len_be));
             offset = sizeof(uint16_t);
-            // Only write_len bytes were consumed by the NLEN field, and offset has
-            // already been reassigned, so advancing by it skips a payload byte.
             data += write_len;
             lc -= write_len;
         }
         offset -= sizeof(uint16_t);
 
         ndef_file_len_new = MAX(ndef_file_len_new, offset + lc);
+
+        // NLEN is reader-supplied and unconstrained by the bounds check above
+        if(ndef_file_len_new > ndef_max_len) {
+            bit_buffer_append_bytes(
+                instance->tx_buffer,
+                type_4_tag_offset_error_apdu,
+                sizeof(type_4_tag_offset_error_apdu));
+            return Type4TagErrorWrongFormat;
+        }
         if(ndef_file_len_new != ndef_file_len) {
             SimpleArray* ndef_data_temp = simple_array_alloc(&simple_array_config_uint8_t);
             if(ndef_file_len_new > 0) {

--- a/lib/nfc/protocols/type_4_tag/type_4_tag_listener_i.c
+++ b/lib/nfc/protocols/type_4_tag/type_4_tag_listener_i.c
@@ -234,7 +234,6 @@ static Type4TagError type_4_tag_listener_iso_write(
         offset -= sizeof(uint16_t);
 
         ndef_file_len_new = MAX(ndef_file_len_new, offset + lc);
-
         // NLEN is reader-supplied and unconstrained by the bounds check above
         if(ndef_file_len_new > ndef_max_len) {
             bit_buffer_append_bytes(
@@ -243,6 +242,7 @@ static Type4TagError type_4_tag_listener_iso_write(
                 sizeof(type_4_tag_offset_error_apdu));
             return Type4TagErrorWrongFormat;
         }
+
         if(ndef_file_len_new != ndef_file_len) {
             SimpleArray* ndef_data_temp = simple_array_alloc(&simple_array_config_uint8_t);
             if(ndef_file_len_new > 0) {

--- a/lib/nfc/protocols/type_4_tag/type_4_tag_listener_i.c
+++ b/lib/nfc/protocols/type_4_tag/type_4_tag_listener_i.c
@@ -212,7 +212,9 @@ static Type4TagError type_4_tag_listener_iso_write(
             const uint8_t write_len = sizeof(uint16_t) - offset;
             ndef_file_len_new = bit_lib_bytes_to_num_be(data, write_len);
             offset = sizeof(uint16_t);
-            data += offset;
+            // Only write_len bytes were consumed by the NLEN field, and offset has
+            // already been reassigned, so advancing by it skips a payload byte.
+            data += write_len;
             lc -= write_len;
         }
         offset -= sizeof(uint16_t);


### PR DESCRIPTION
## Description

In `type_4_tag_listener_iso_write()`, a write that starts inside the two-byte NLEN field consumes `write_len = sizeof(uint16_t) - offset` bytes for that field. The payload pointer is then advanced by `offset` instead:

```c
const uint8_t write_len = sizeof(uint16_t) - offset;
ndef_file_len_new = bit_lib_bytes_to_num_be(data, write_len);
offset = sizeof(uint16_t);
data += offset;      // offset was just reassigned to 2
lc -= write_len;
```

`offset` has already been reassigned to `sizeof(uint16_t)` on the line above, so `data` always moves forward by 2 regardless of how much was actually consumed.

With `offset == 0` the two agree (`write_len` is 2), which is why this goes unnoticed. With `offset == 1` only one byte belongs to NLEN, so:

- the NDEF payload is taken starting one byte too far in, shifting the written content by one, and
- `lc` was only reduced by 1, so the copy runs one byte past the end of the reader's APDU data.

`offset` comes straight from the command header (`offset = (p1 << 8) + p2`), so a reader only has to send `P1 = 0x00`, `P2 = 0x01` to reach it.

## Fix

Advance by the number of bytes actually consumed:

```c
data += write_len;
```

Behaviour at `offset == 0` is unchanged, since `write_len` is 2 there.

 ## Additional fixes ported from unleashed 

While reviewing the fix above in DarkFlippers/unleashed-firmware#1049, @mishamyte found four more   ways a reader can crash a Flipper emulating a Type 4 Tag and   fixed them in DarkFlippers/unleashed-firmware#1051, stacked on     top. This repo carries the same code, so it carries the same    crashes. Both of his commits are included here with their    original authorship.

## Verification

`./fbt firmware_all` builds clean (`f7-firmware-C`).

This file is byte-identical between this repo and DarkFlippers/unleashed-firmware (blob `7da6fadc`), and the fixed file is likewise identical to the one in DarkFlippers/unleashed-firmware#1049 (blob `84ccfb9b`) — so this is the same change, not a re-derivation.